### PR TITLE
Add an optional, vendor-neutral pre-payment policy hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,74 @@ def verify_webhook(payload, signature, secret):
 
 Check the `X-Webhook-Signature` header against the payload.
 
+## Pre-Payment Policy Hook
+
+An optional, vendor-neutral hook lets an external policy endpoint **allow or deny a payment before it executes**. It is off by default — when `PRE_PAYMENT_HOOK_URL` is unset, behaviour is exactly as before. When set, every outgoing payment (`pay_l402_api`, `pay_invoice`, `keysend`, `pay_lightning_address`) is checked against your endpoint first; a denial aborts the payment before any funds move.
+
+This is useful for spending policies, approval workflows, compliance checks, or any external authorization layer. The hook protocol is generic, so any service implementing the request/response contract below can be wired in by configuration alone.
+
+### Configuration
+
+| Env var | Default | Description |
+|---|---|---|
+| `PRE_PAYMENT_HOOK_URL` | _(unset)_ | Policy endpoint to POST each payment proposal to. Unset disables the hook entirely. |
+| `PRE_PAYMENT_HOOK_TIMEOUT_MS` | `3000` | Per-request timeout in milliseconds. |
+| `PRE_PAYMENT_HOOK_FAIL_MODE` | `closed` | `closed` denies a payment if the hook errors or times out; `open` lets it proceed. Default is fail-closed. |
+
+```jsonc
+{
+  "mcpServers": {
+    "lightning-wallet": {
+      "command": "npx",
+      "args": ["lightning-wallet-mcp"],
+      "env": {
+        "LIGHTNING_WALLET_API_KEY": "your-api-key",
+        "PRE_PAYMENT_HOOK_URL": "https://your-policy-endpoint.example/hook"
+      }
+    }
+  }
+}
+```
+
+### Hook request (POST from the client)
+
+The proposal describes only the proposed payment — **it never includes your wallet API key**.
+
+```json
+{
+  "proposal_id": "f7e1…",
+  "agent_id": 42,
+  "protocol": "l402",
+  "destination_or_url": "https://api.example/paid-endpoint",
+  "amount_sats": null,
+  "max_payment_sats": 1000,
+  "method": "GET",
+  "ts": "2026-06-06T18:00:00.000Z"
+}
+```
+
+`protocol` is one of `l402`, `x402`, `bolt11`, `keysend`, `lnaddress`. `amount_sats` is the exact amount when it is known at hook time: for `keysend` and `lnaddress` it is the requested amount, and for `bolt11` it is decoded locally from the invoice (no extra API call). For `l402`/`x402` it is `null` because the amount is set by the payment challenge at execution time — there the hook enforces `max_payment_sats` (the agent-authorised ceiling) up front, and the exact settled amount is available afterward via [webhooks](#webhooks). `max_payment_sats` is the agent-authorised ceiling when applicable.
+
+**Exactly what leaves the wallet.** Only the eight fields above are sent to your hook endpoint: `proposal_id`, `agent_id`, `protocol`, `destination_or_url`, `amount_sats`, `max_payment_sats`, `method`, `ts`. The wallet API key and any other credentials are **never** included.
+
+**Coverage.** The hook gates every agent-initiated spend: `pay_l402_api`, `pay_invoice`, `keysend`, `pay_lightning_address`, and Nostr zaps. Operator-scoped fund management (withdrawals, agent funding, agent-to-agent transfers) is intentionally **not** gated — those are operator actions, not agent spends.
+
+### Hook response (your endpoint returns)
+
+```json
+{ "decision": "allow" }
+```
+
+```json
+{ "decision": "deny", "reason": { "code": "over_limit", "message": "Exceeds per-transaction limit" } }
+```
+
+- `allow` → the payment proceeds.
+- `deny` → the payment is aborted and the tool returns a `PolicyDenied` error surfacing `reason.message`.
+- An optional `attestation` field (any JSON) is treated as opaque by the client — it is logged to stderr and otherwise ignored, so a policy service can return a signed decision for downstream auditing.
+
+On a hook error, timeout, or unrecognized response, the `PRE_PAYMENT_HOOK_FAIL_MODE` applies (deny by default).
+
 ## Pricing
 
 Lightning Faucet charges a 2% platform fee (min 1 sat) on outgoing payments:

--- a/dist/bolt11.d.ts
+++ b/dist/bolt11.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Minimal, dependency-free BOLT11 amount decoder.
+ *
+ * Reads only the amount from the invoice's human-readable prefix (HRP). It does
+ * NOT bech32-decode the data part and makes no network call. Returns the amount
+ * in sats, or null when the invoice is amountless or cannot be confidently
+ * parsed — callers treat null as "amount unknown" and degrade gracefully.
+ */
+export declare function bolt11AmountSats(invoice: string): number | null;

--- a/dist/bolt11.js
+++ b/dist/bolt11.js
@@ -1,0 +1,54 @@
+"use strict";
+/**
+ * Minimal, dependency-free BOLT11 amount decoder.
+ *
+ * Reads only the amount from the invoice's human-readable prefix (HRP). It does
+ * NOT bech32-decode the data part and makes no network call. Returns the amount
+ * in sats, or null when the invoice is amountless or cannot be confidently
+ * parsed — callers treat null as "amount unknown" and degrade gracefully.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.bolt11AmountSats = bolt11AmountSats;
+// msats per 1 unit of each multiplier (1 BTC = 1e11 msat).
+const MSAT_PER_UNIT = {
+    m: 1e8, // milli  (1e-3 BTC)
+    u: 1e5, // micro  (1e-6 BTC)
+    n: 1e2, // nano   (1e-9 BTC)
+    p: 1e-1, // pico  (1e-12 BTC)
+};
+function bolt11AmountSats(invoice) {
+    try {
+        const lower = invoice.trim().toLowerCase();
+        if (!lower.startsWith('ln'))
+            return null;
+        // The bech32 data part never contains '1', so the LAST '1' is the separator
+        // between the human-readable prefix and the data.
+        const sep = lower.lastIndexOf('1');
+        if (sep < 1)
+            return null;
+        const hrp = lower.slice(0, sep);
+        // hrp = 'ln' + currency-prefix + <digits><multiplier?>. Amountless invoices
+        // (no digits) and unknown currency prefixes do not match → null.
+        const match = hrp.match(/^ln(?:bcrt|bc|tb|sb)(\d+)([munp])?$/);
+        if (!match)
+            return null;
+        const digits = match[1];
+        const multiplier = match[2];
+        let msat;
+        if (multiplier) {
+            const factor = MSAT_PER_UNIT[multiplier];
+            if (factor === undefined)
+                return null;
+            msat = Number(digits) * factor;
+        }
+        else {
+            msat = Number(digits) * 1e11; // whole BTC
+        }
+        if (!Number.isFinite(msat) || msat < 0)
+            return null;
+        return Math.round(msat / 1000);
+    }
+    catch {
+        return null;
+    }
+}

--- a/dist/lightning-faucet.d.ts
+++ b/dist/lightning-faucet.d.ts
@@ -118,7 +118,24 @@ interface WhoamiResponse extends ApiResponse {
 }
 export declare class LightningFaucetClient {
     private apiKey;
+    private agentIdCache;
     constructor(apiKey: string);
+    /**
+     * Resolve the current agent id for hook proposals (best-effort, cached).
+     * Returns null if it cannot be determined; a payment is never blocked solely
+     * because identity resolution failed — that decision is left to the policy hook.
+     */
+    private resolveAgentId;
+    /**
+     * Run the optional pre-payment policy hook before executing a payment.
+     *
+     * No-op when `PRE_PAYMENT_HOOK_URL` is unset (behaviour is unchanged). When a
+     * hook is configured this POSTs a vendor-neutral proposal and throws
+     * `PolicyDenied` if the hook — or fail-closed handling of a hook error —
+     * denies the payment. Only the four explicit payment methods call this; it is
+     * invoked before any funds-moving request is sent.
+     */
+    private enforcePrePaymentPolicy;
     /**
      * Make an API request to Lightning Faucet
      */

--- a/dist/lightning-faucet.js
+++ b/dist/lightning-faucet.js
@@ -7,14 +7,74 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.LightningFaucetClient = void 0;
 exports.registerOperator = registerOperator;
+const pre_payment_hook_js_1 = require("./pre-payment-hook.js");
+const bolt11_js_1 = require("./bolt11.js");
 const API_BASE_URL = process.env.LIGHTNING_WALLET_API_URL || 'https://lightningfaucet.com/ai-agents/api';
+function safeStringify(value) {
+    try {
+        return JSON.stringify(value);
+    }
+    catch {
+        return '[unserializable]';
+    }
+}
 class LightningFaucetClient {
     apiKey;
+    agentIdCache;
     constructor(apiKey) {
         if (!apiKey) {
             throw new Error('API key is required');
         }
         this.apiKey = apiKey;
+    }
+    /**
+     * Resolve the current agent id for hook proposals (best-effort, cached).
+     * Returns null if it cannot be determined; a payment is never blocked solely
+     * because identity resolution failed — that decision is left to the policy hook.
+     */
+    async resolveAgentId() {
+        if (this.agentIdCache !== undefined) {
+            return this.agentIdCache;
+        }
+        try {
+            const who = await this.whoami();
+            this.agentIdCache = who.id || null;
+        }
+        catch {
+            this.agentIdCache = null;
+        }
+        return this.agentIdCache;
+    }
+    /**
+     * Run the optional pre-payment policy hook before executing a payment.
+     *
+     * No-op when `PRE_PAYMENT_HOOK_URL` is unset (behaviour is unchanged). When a
+     * hook is configured this POSTs a vendor-neutral proposal and throws
+     * `PolicyDenied` if the hook — or fail-closed handling of a hook error —
+     * denies the payment. Only the four explicit payment methods call this; it is
+     * invoked before any funds-moving request is sent.
+     */
+    async enforcePrePaymentPolicy(params) {
+        const config = (0, pre_payment_hook_js_1.getPrePaymentHookConfig)();
+        if (!config) {
+            return;
+        }
+        const agentId = await this.resolveAgentId();
+        const proposal = {
+            proposal_id: globalThis.crypto.randomUUID(),
+            agent_id: agentId,
+            protocol: params.protocol,
+            destination_or_url: params.destinationOrUrl,
+            amount_sats: params.amountSats,
+            max_payment_sats: params.maxPaymentSats,
+            method: params.method ?? null,
+            ts: new Date().toISOString(),
+        };
+        const { attestation } = await (0, pre_payment_hook_js_1.runPrePaymentHook)(proposal, config);
+        if (attestation !== undefined) {
+            // Opaque to this client — logged on stderr to avoid corrupting MCP stdio.
+            console.error(`[pre-payment-hook] payment allowed with attestation: ${safeStringify(attestation)}`);
+        }
     }
     /**
      * Make an API request to Lightning Faucet
@@ -56,6 +116,15 @@ class LightningFaucetClient {
      * Pay an L402-protected API endpoint
      */
     async l402Pay(url, method = 'GET', body, maxPaymentSats = 1000) {
+        // L402 vs X402 is auto-detected server-side; the actual amount is set by the
+        // challenge, so only the agent-authorised ceiling is known at hook time.
+        await this.enforcePrePaymentPolicy({
+            protocol: 'l402',
+            destinationOrUrl: url,
+            amountSats: null,
+            maxPaymentSats,
+            method: method.toUpperCase(),
+        });
         const requestData = {
             url,
             method: method.toUpperCase(),
@@ -92,6 +161,15 @@ class LightningFaucetClient {
      * Pay a BOLT11 Lightning invoice
      */
     async payInvoice(bolt11, maxFeeSats) {
+        // Decode the amount from the invoice locally (no extra API call) so the hook
+        // receives the exact amount; null only if the invoice is amountless/unparseable.
+        await this.enforcePrePaymentPolicy({
+            protocol: 'bolt11',
+            destinationOrUrl: bolt11,
+            amountSats: (0, bolt11_js_1.bolt11AmountSats)(bolt11),
+            maxPaymentSats: null,
+            method: null,
+        });
         const data = {
             invoice: bolt11,
         };
@@ -572,6 +650,13 @@ class LightningFaucetClient {
      * Pay to a Lightning address
      */
     async payLightningAddress(address, amountSats, comment) {
+        await this.enforcePrePaymentPolicy({
+            protocol: 'lnaddress',
+            destinationOrUrl: address,
+            amountSats,
+            maxPaymentSats: amountSats,
+            method: null,
+        });
         const data = {
             address,
             amount_sats: amountSats,
@@ -662,6 +747,13 @@ class LightningFaucetClient {
      * Send keysend payment
      */
     async keysend(destination, amountSats, message) {
+        await this.enforcePrePaymentPolicy({
+            protocol: 'keysend',
+            destinationOrUrl: destination,
+            amountSats,
+            maxPaymentSats: amountSats,
+            method: null,
+        });
         const data = {
             destination,
             amount_sats: amountSats,
@@ -713,6 +805,15 @@ class LightningFaucetClient {
      * Falls back to regular Lightning address payment if recipient doesn't support NIP-57
      */
     async nostrZap(address, amountSats, recipientPubkey, content, eventId, relays) {
+        // A Nostr zap settles as a Lightning-address payment, so it is an agent spend
+        // and must pass the policy hook like any other.
+        await this.enforcePrePaymentPolicy({
+            protocol: 'lnaddress',
+            destinationOrUrl: address,
+            amountSats,
+            maxPaymentSats: amountSats,
+            method: null,
+        });
         const data = {
             address,
             amount_sats: amountSats,

--- a/dist/pre-payment-hook.d.ts
+++ b/dist/pre-payment-hook.d.ts
@@ -1,0 +1,82 @@
+/**
+ * Pre-Payment Policy Hook
+ *
+ * An optional, vendor-neutral hook that lets an external policy endpoint allow
+ * or deny a payment *before* it executes. When `PRE_PAYMENT_HOOK_URL` is unset
+ * the hook is inert and payment behaviour is identical to having no hook at all.
+ *
+ * This module contains no vendor-specific logic. It POSTs a generic payment
+ * proposal and interprets a generic decision, so any policy service that speaks
+ * the documented request/response contract can be wired in by configuration
+ * alone. The proposal deliberately carries NO wallet credentials.
+ */
+export type PaymentProtocol = 'l402' | 'x402' | 'bolt11' | 'keysend' | 'lnaddress';
+export type HookFailMode = 'closed' | 'open';
+export interface PrePaymentProposal {
+    /** Unique id for this proposal (one per payment attempt). */
+    proposal_id: string;
+    /** The paying agent's id, when resolvable; null otherwise. */
+    agent_id: number | null;
+    /** Payment protocol being attempted. */
+    protocol: PaymentProtocol;
+    /** Destination address, node pubkey, lightning address, invoice, or target URL. */
+    destination_or_url: string;
+    /** Exact amount when known at hook time; null when the protocol determines it later. */
+    amount_sats: number | null;
+    /** Upper bound the agent authorised, when applicable; null otherwise. */
+    max_payment_sats: number | null;
+    /** HTTP method for L402/X402 URL payments; null for direct Lightning payments. */
+    method: string | null;
+    /** ISO-8601 timestamp of the proposal. */
+    ts: string;
+}
+export interface HookDecisionReason {
+    code?: string;
+    message?: string;
+}
+export interface HookDecision {
+    decision: 'allow' | 'deny';
+    reason?: HookDecisionReason;
+    /** Opaque to this client; forwarded/logged only. */
+    attestation?: unknown;
+}
+export interface PrePaymentHookConfig {
+    url: string;
+    timeoutMs: number;
+    failMode: HookFailMode;
+}
+/**
+ * Read hook configuration from the environment. Returns null when no hook URL is
+ * configured, in which case callers MUST behave exactly as before.
+ *
+ * - `PRE_PAYMENT_HOOK_URL` — when set, enables the hook.
+ * - `PRE_PAYMENT_HOOK_TIMEOUT_MS` — request timeout; defaults to 3000.
+ * - `PRE_PAYMENT_HOOK_FAIL_MODE` — `closed` (default) denies on hook error/timeout;
+ *   `open` proceeds on hook error/timeout.
+ */
+export declare function getPrePaymentHookConfig(env?: Record<string, string | undefined>): PrePaymentHookConfig | null;
+/**
+ * Error thrown when a payment is denied — either explicitly by the hook
+ * (`decision: "deny"`) or implicitly by a hook error under fail-closed mode.
+ */
+export declare class PolicyDenied extends Error {
+    readonly code: string;
+    readonly reason?: HookDecisionReason;
+    constructor(message: string, code?: string, reason?: HookDecisionReason);
+}
+export interface RunHookDeps {
+    /** Injectable fetch, primarily for tests. Defaults to the global fetch. */
+    fetchImpl?: typeof fetch;
+}
+/**
+ * Run the pre-payment hook for a proposal.
+ *
+ * - decision `allow`: resolves with the (opaque) attestation, if any.
+ * - decision `deny`: throws {@link PolicyDenied} carrying the structured reason.
+ * - transport error / timeout / non-2xx / malformed response: applies failMode —
+ *   `closed` throws {@link PolicyDenied}; `open` resolves (payment proceeds) after
+ *   logging the failure to stderr.
+ */
+export declare function runPrePaymentHook(proposal: PrePaymentProposal, config: PrePaymentHookConfig, deps?: RunHookDeps): Promise<{
+    attestation?: unknown;
+}>;

--- a/dist/pre-payment-hook.js
+++ b/dist/pre-payment-hook.js
@@ -1,0 +1,125 @@
+"use strict";
+/**
+ * Pre-Payment Policy Hook
+ *
+ * An optional, vendor-neutral hook that lets an external policy endpoint allow
+ * or deny a payment *before* it executes. When `PRE_PAYMENT_HOOK_URL` is unset
+ * the hook is inert and payment behaviour is identical to having no hook at all.
+ *
+ * This module contains no vendor-specific logic. It POSTs a generic payment
+ * proposal and interprets a generic decision, so any policy service that speaks
+ * the documented request/response contract can be wired in by configuration
+ * alone. The proposal deliberately carries NO wallet credentials.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.PolicyDenied = void 0;
+exports.getPrePaymentHookConfig = getPrePaymentHookConfig;
+exports.runPrePaymentHook = runPrePaymentHook;
+const DEFAULT_TIMEOUT_MS = 3000;
+/**
+ * Read hook configuration from the environment. Returns null when no hook URL is
+ * configured, in which case callers MUST behave exactly as before.
+ *
+ * - `PRE_PAYMENT_HOOK_URL` — when set, enables the hook.
+ * - `PRE_PAYMENT_HOOK_TIMEOUT_MS` — request timeout; defaults to 3000.
+ * - `PRE_PAYMENT_HOOK_FAIL_MODE` — `closed` (default) denies on hook error/timeout;
+ *   `open` proceeds on hook error/timeout.
+ */
+function getPrePaymentHookConfig(env = process.env) {
+    const url = env.PRE_PAYMENT_HOOK_URL?.trim();
+    if (!url) {
+        return null;
+    }
+    const timeoutRaw = env.PRE_PAYMENT_HOOK_TIMEOUT_MS?.trim();
+    const parsedTimeout = timeoutRaw ? Number.parseInt(timeoutRaw, 10) : NaN;
+    const timeoutMs = Number.isFinite(parsedTimeout) && parsedTimeout > 0 ? parsedTimeout : DEFAULT_TIMEOUT_MS;
+    // Default fail-closed: when a hook is configured, a hook error denies the payment.
+    const failMode = env.PRE_PAYMENT_HOOK_FAIL_MODE?.trim().toLowerCase() === 'open' ? 'open' : 'closed';
+    return { url, timeoutMs, failMode };
+}
+/**
+ * Error thrown when a payment is denied — either explicitly by the hook
+ * (`decision: "deny"`) or implicitly by a hook error under fail-closed mode.
+ */
+class PolicyDenied extends Error {
+    code;
+    reason;
+    constructor(message, code = 'policy_denied', reason) {
+        super(message);
+        this.name = 'PolicyDenied';
+        this.code = code;
+        this.reason = reason;
+    }
+}
+exports.PolicyDenied = PolicyDenied;
+/**
+ * Run the pre-payment hook for a proposal.
+ *
+ * - decision `allow`: resolves with the (opaque) attestation, if any.
+ * - decision `deny`: throws {@link PolicyDenied} carrying the structured reason.
+ * - transport error / timeout / non-2xx / malformed response: applies failMode —
+ *   `closed` throws {@link PolicyDenied}; `open` resolves (payment proceeds) after
+ *   logging the failure to stderr.
+ */
+async function runPrePaymentHook(proposal, config, deps = {}) {
+    const doFetch = deps.fetchImpl ?? fetch;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), config.timeoutMs);
+    // The timer lives in a try/finally with NO catch: a fail-closed PolicyDenied
+    // (from applyFailMode or the deny branch) propagates straight out, clearing
+    // the timer, and is never caught and re-wrapped. Only the fetch and the body
+    // read are wrapped in their own try/catch, so their failures map to fail-mode
+    // exactly once with the right detail.
+    try {
+        let response;
+        try {
+            response = await doFetch(config.url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(proposal),
+                signal: controller.signal,
+            });
+        }
+        catch (err) {
+            return applyFailMode(config, transportDetail(err, config));
+        }
+        // Non-2xx is handled OUTSIDE the fetch try/catch so the status detail is
+        // preserved and fail-mode runs once.
+        if (!response.ok) {
+            return applyFailMode(config, `policy hook returned HTTP ${response.status}`);
+        }
+        let decision;
+        try {
+            decision = (await response.json());
+        }
+        catch (err) {
+            return applyFailMode(config, transportDetail(err, config, 'policy hook returned an unparseable body'));
+        }
+        if (decision?.decision === 'allow') {
+            return { attestation: decision.attestation };
+        }
+        if (decision?.decision === 'deny') {
+            const reason = decision.reason;
+            const detail = reason?.message || 'payment denied by policy';
+            throw new PolicyDenied(`Payment blocked by pre-payment policy hook: ${detail}`, reason?.code || 'policy_denied', reason);
+        }
+        // Malformed/unknown decision — treat as a hook error and apply the fail mode.
+        return applyFailMode(config, 'policy hook returned an unrecognized decision');
+    }
+    finally {
+        clearTimeout(timer);
+    }
+}
+function transportDetail(err, config, fallback = 'policy hook request failed') {
+    return err instanceof Error && err.name === 'AbortError'
+        ? `policy hook timed out after ${config.timeoutMs}ms`
+        : fallback;
+}
+function applyFailMode(config, detail) {
+    if (config.failMode === 'open') {
+        // Fail-open: allow the payment, but record the hook failure on stderr.
+        console.error(`[pre-payment-hook] fail-open: proceeding despite ${detail}`);
+        return {};
+    }
+    throw new PolicyDenied(`Payment blocked by pre-payment policy hook (fail-closed): ${detail}`, 'policy_hook_unavailable');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lightning-wallet-mcp",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lightning-wallet-mcp",
-      "version": "1.2.7",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "tsc",
     "watch": "tsc --watch",
     "start": "node dist/index.js",
+    "test": "npm run build && node --test test/*.test.js",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/src/bolt11.ts
+++ b/src/bolt11.ts
@@ -1,0 +1,51 @@
+/**
+ * Minimal, dependency-free BOLT11 amount decoder.
+ *
+ * Reads only the amount from the invoice's human-readable prefix (HRP). It does
+ * NOT bech32-decode the data part and makes no network call. Returns the amount
+ * in sats, or null when the invoice is amountless or cannot be confidently
+ * parsed — callers treat null as "amount unknown" and degrade gracefully.
+ */
+
+// msats per 1 unit of each multiplier (1 BTC = 1e11 msat).
+const MSAT_PER_UNIT: Record<string, number> = {
+  m: 1e8, // milli  (1e-3 BTC)
+  u: 1e5, // micro  (1e-6 BTC)
+  n: 1e2, // nano   (1e-9 BTC)
+  p: 1e-1, // pico  (1e-12 BTC)
+};
+
+export function bolt11AmountSats(invoice: string): number | null {
+  try {
+    const lower = invoice.trim().toLowerCase();
+    if (!lower.startsWith('ln')) return null;
+
+    // The bech32 data part never contains '1', so the LAST '1' is the separator
+    // between the human-readable prefix and the data.
+    const sep = lower.lastIndexOf('1');
+    if (sep < 1) return null;
+    const hrp = lower.slice(0, sep);
+
+    // hrp = 'ln' + currency-prefix + <digits><multiplier?>. Amountless invoices
+    // (no digits) and unknown currency prefixes do not match → null.
+    const match = hrp.match(/^ln(?:bcrt|bc|tb|sb)(\d+)([munp])?$/);
+    if (!match) return null;
+
+    const digits = match[1];
+    const multiplier = match[2];
+
+    let msat: number;
+    if (multiplier) {
+      const factor = MSAT_PER_UNIT[multiplier];
+      if (factor === undefined) return null;
+      msat = Number(digits) * factor;
+    } else {
+      msat = Number(digits) * 1e11; // whole BTC
+    }
+
+    if (!Number.isFinite(msat) || msat < 0) return null;
+    return Math.round(msat / 1000);
+  } catch {
+    return null;
+  }
+}

--- a/src/lightning-faucet.ts
+++ b/src/lightning-faucet.ts
@@ -4,7 +4,23 @@
  * Handles communication with the Lightning Faucet AI Agent Wallet API.
  */
 
+import {
+  PaymentProtocol,
+  PrePaymentProposal,
+  getPrePaymentHookConfig,
+  runPrePaymentHook,
+} from './pre-payment-hook.js';
+import { bolt11AmountSats } from './bolt11.js';
+
 const API_BASE_URL = process.env.LIGHTNING_WALLET_API_URL || 'https://lightningfaucet.com/ai-agents/api';
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '[unserializable]';
+  }
+}
 
 // Response interfaces
 interface ApiResponse {
@@ -144,12 +160,71 @@ interface WhoamiResponse extends ApiResponse {
 
 export class LightningFaucetClient {
   private apiKey: string;
+  private agentIdCache: number | null | undefined;
 
   constructor(apiKey: string) {
     if (!apiKey) {
       throw new Error('API key is required');
     }
     this.apiKey = apiKey;
+  }
+
+  /**
+   * Resolve the current agent id for hook proposals (best-effort, cached).
+   * Returns null if it cannot be determined; a payment is never blocked solely
+   * because identity resolution failed — that decision is left to the policy hook.
+   */
+  private async resolveAgentId(): Promise<number | null> {
+    if (this.agentIdCache !== undefined) {
+      return this.agentIdCache;
+    }
+    try {
+      const who = await this.whoami();
+      this.agentIdCache = who.id || null;
+    } catch {
+      this.agentIdCache = null;
+    }
+    return this.agentIdCache;
+  }
+
+  /**
+   * Run the optional pre-payment policy hook before executing a payment.
+   *
+   * No-op when `PRE_PAYMENT_HOOK_URL` is unset (behaviour is unchanged). When a
+   * hook is configured this POSTs a vendor-neutral proposal and throws
+   * `PolicyDenied` if the hook — or fail-closed handling of a hook error —
+   * denies the payment. Only the four explicit payment methods call this; it is
+   * invoked before any funds-moving request is sent.
+   */
+  private async enforcePrePaymentPolicy(params: {
+    protocol: PaymentProtocol;
+    destinationOrUrl: string;
+    amountSats: number | null;
+    maxPaymentSats: number | null;
+    method?: string | null;
+  }): Promise<void> {
+    const config = getPrePaymentHookConfig();
+    if (!config) {
+      return;
+    }
+
+    const agentId = await this.resolveAgentId();
+    const proposal: PrePaymentProposal = {
+      proposal_id: globalThis.crypto.randomUUID(),
+      agent_id: agentId,
+      protocol: params.protocol,
+      destination_or_url: params.destinationOrUrl,
+      amount_sats: params.amountSats,
+      max_payment_sats: params.maxPaymentSats,
+      method: params.method ?? null,
+      ts: new Date().toISOString(),
+    };
+
+    const { attestation } = await runPrePaymentHook(proposal, config);
+    if (attestation !== undefined) {
+      // Opaque to this client — logged on stderr to avoid corrupting MCP stdio.
+      console.error(`[pre-payment-hook] payment allowed with attestation: ${safeStringify(attestation)}`);
+    }
   }
 
   /**
@@ -219,6 +294,16 @@ export class LightningFaucetClient {
     usdcAmount?: number;
     rawResponse: L402PayResponse;
   }> {
+    // L402 vs X402 is auto-detected server-side; the actual amount is set by the
+    // challenge, so only the agent-authorised ceiling is known at hook time.
+    await this.enforcePrePaymentPolicy({
+      protocol: 'l402',
+      destinationOrUrl: url,
+      amountSats: null,
+      maxPaymentSats,
+      method: method.toUpperCase(),
+    });
+
     const requestData: Record<string, unknown> = {
       url,
       method: method.toUpperCase(),
@@ -270,6 +355,16 @@ export class LightningFaucetClient {
     newBalance: number;
     rawResponse: PayInvoiceResponse;
   }> {
+    // Decode the amount from the invoice locally (no extra API call) so the hook
+    // receives the exact amount; null only if the invoice is amountless/unparseable.
+    await this.enforcePrePaymentPolicy({
+      protocol: 'bolt11',
+      destinationOrUrl: bolt11,
+      amountSats: bolt11AmountSats(bolt11),
+      maxPaymentSats: null,
+      method: null,
+    });
+
     const data: Record<string, unknown> = {
       invoice: bolt11,
     };
@@ -1084,6 +1179,14 @@ export class LightningFaucetClient {
     newBalance: number;
     rawResponse: ApiResponse;
   }> {
+    await this.enforcePrePaymentPolicy({
+      protocol: 'lnaddress',
+      destinationOrUrl: address,
+      amountSats,
+      maxPaymentSats: amountSats,
+      method: null,
+    });
+
     const data: Record<string, unknown> = {
       address,
       amount_sats: amountSats,
@@ -1240,6 +1343,14 @@ export class LightningFaucetClient {
     newBalance: number;
     rawResponse: ApiResponse;
   }> {
+    await this.enforcePrePaymentPolicy({
+      protocol: 'keysend',
+      destinationOrUrl: destination,
+      amountSats,
+      maxPaymentSats: amountSats,
+      method: null,
+    });
+
     const data: Record<string, unknown> = {
       destination,
       amount_sats: amountSats,
@@ -1336,6 +1447,16 @@ export class LightningFaucetClient {
     zapType: 'nip57' | 'fallback';
     rawResponse: ApiResponse;
   }> {
+    // A Nostr zap settles as a Lightning-address payment, so it is an agent spend
+    // and must pass the policy hook like any other.
+    await this.enforcePrePaymentPolicy({
+      protocol: 'lnaddress',
+      destinationOrUrl: address,
+      amountSats,
+      maxPaymentSats: amountSats,
+      method: null,
+    });
+
     const data: Record<string, unknown> = {
       address,
       amount_sats: amountSats,

--- a/src/pre-payment-hook.ts
+++ b/src/pre-payment-hook.ts
@@ -1,0 +1,196 @@
+/**
+ * Pre-Payment Policy Hook
+ *
+ * An optional, vendor-neutral hook that lets an external policy endpoint allow
+ * or deny a payment *before* it executes. When `PRE_PAYMENT_HOOK_URL` is unset
+ * the hook is inert and payment behaviour is identical to having no hook at all.
+ *
+ * This module contains no vendor-specific logic. It POSTs a generic payment
+ * proposal and interprets a generic decision, so any policy service that speaks
+ * the documented request/response contract can be wired in by configuration
+ * alone. The proposal deliberately carries NO wallet credentials.
+ */
+
+export type PaymentProtocol = 'l402' | 'x402' | 'bolt11' | 'keysend' | 'lnaddress';
+export type HookFailMode = 'closed' | 'open';
+
+export interface PrePaymentProposal {
+  /** Unique id for this proposal (one per payment attempt). */
+  proposal_id: string;
+  /** The paying agent's id, when resolvable; null otherwise. */
+  agent_id: number | null;
+  /** Payment protocol being attempted. */
+  protocol: PaymentProtocol;
+  /** Destination address, node pubkey, lightning address, invoice, or target URL. */
+  destination_or_url: string;
+  /** Exact amount when known at hook time; null when the protocol determines it later. */
+  amount_sats: number | null;
+  /** Upper bound the agent authorised, when applicable; null otherwise. */
+  max_payment_sats: number | null;
+  /** HTTP method for L402/X402 URL payments; null for direct Lightning payments. */
+  method: string | null;
+  /** ISO-8601 timestamp of the proposal. */
+  ts: string;
+}
+
+export interface HookDecisionReason {
+  code?: string;
+  message?: string;
+}
+
+export interface HookDecision {
+  decision: 'allow' | 'deny';
+  reason?: HookDecisionReason;
+  /** Opaque to this client; forwarded/logged only. */
+  attestation?: unknown;
+}
+
+export interface PrePaymentHookConfig {
+  url: string;
+  timeoutMs: number;
+  failMode: HookFailMode;
+}
+
+const DEFAULT_TIMEOUT_MS = 3000;
+
+/**
+ * Read hook configuration from the environment. Returns null when no hook URL is
+ * configured, in which case callers MUST behave exactly as before.
+ *
+ * - `PRE_PAYMENT_HOOK_URL` — when set, enables the hook.
+ * - `PRE_PAYMENT_HOOK_TIMEOUT_MS` — request timeout; defaults to 3000.
+ * - `PRE_PAYMENT_HOOK_FAIL_MODE` — `closed` (default) denies on hook error/timeout;
+ *   `open` proceeds on hook error/timeout.
+ */
+export function getPrePaymentHookConfig(
+  env: Record<string, string | undefined> = process.env
+): PrePaymentHookConfig | null {
+  const url = env.PRE_PAYMENT_HOOK_URL?.trim();
+  if (!url) {
+    return null;
+  }
+
+  const timeoutRaw = env.PRE_PAYMENT_HOOK_TIMEOUT_MS?.trim();
+  const parsedTimeout = timeoutRaw ? Number.parseInt(timeoutRaw, 10) : NaN;
+  const timeoutMs =
+    Number.isFinite(parsedTimeout) && parsedTimeout > 0 ? parsedTimeout : DEFAULT_TIMEOUT_MS;
+
+  // Default fail-closed: when a hook is configured, a hook error denies the payment.
+  const failMode: HookFailMode =
+    env.PRE_PAYMENT_HOOK_FAIL_MODE?.trim().toLowerCase() === 'open' ? 'open' : 'closed';
+
+  return { url, timeoutMs, failMode };
+}
+
+/**
+ * Error thrown when a payment is denied — either explicitly by the hook
+ * (`decision: "deny"`) or implicitly by a hook error under fail-closed mode.
+ */
+export class PolicyDenied extends Error {
+  readonly code: string;
+  readonly reason?: HookDecisionReason;
+
+  constructor(message: string, code = 'policy_denied', reason?: HookDecisionReason) {
+    super(message);
+    this.name = 'PolicyDenied';
+    this.code = code;
+    this.reason = reason;
+  }
+}
+
+export interface RunHookDeps {
+  /** Injectable fetch, primarily for tests. Defaults to the global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Run the pre-payment hook for a proposal.
+ *
+ * - decision `allow`: resolves with the (opaque) attestation, if any.
+ * - decision `deny`: throws {@link PolicyDenied} carrying the structured reason.
+ * - transport error / timeout / non-2xx / malformed response: applies failMode —
+ *   `closed` throws {@link PolicyDenied}; `open` resolves (payment proceeds) after
+ *   logging the failure to stderr.
+ */
+export async function runPrePaymentHook(
+  proposal: PrePaymentProposal,
+  config: PrePaymentHookConfig,
+  deps: RunHookDeps = {}
+): Promise<{ attestation?: unknown }> {
+  const doFetch = deps.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), config.timeoutMs);
+
+  // The timer lives in a try/finally with NO catch: a fail-closed PolicyDenied
+  // (from applyFailMode or the deny branch) propagates straight out, clearing
+  // the timer, and is never caught and re-wrapped. Only the fetch and the body
+  // read are wrapped in their own try/catch, so their failures map to fail-mode
+  // exactly once with the right detail.
+  try {
+    let response: Awaited<ReturnType<typeof doFetch>>;
+    try {
+      response = await doFetch(config.url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(proposal),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      return applyFailMode(config, transportDetail(err, config));
+    }
+
+    // Non-2xx is handled OUTSIDE the fetch try/catch so the status detail is
+    // preserved and fail-mode runs once.
+    if (!response.ok) {
+      return applyFailMode(config, `policy hook returned HTTP ${response.status}`);
+    }
+
+    let decision: HookDecision;
+    try {
+      decision = (await response.json()) as HookDecision;
+    } catch (err) {
+      return applyFailMode(config, transportDetail(err, config, 'policy hook returned an unparseable body'));
+    }
+
+    if (decision?.decision === 'allow') {
+      return { attestation: decision.attestation };
+    }
+
+    if (decision?.decision === 'deny') {
+      const reason = decision.reason;
+      const detail = reason?.message || 'payment denied by policy';
+      throw new PolicyDenied(
+        `Payment blocked by pre-payment policy hook: ${detail}`,
+        reason?.code || 'policy_denied',
+        reason
+      );
+    }
+
+    // Malformed/unknown decision — treat as a hook error and apply the fail mode.
+    return applyFailMode(config, 'policy hook returned an unrecognized decision');
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function transportDetail(
+  err: unknown,
+  config: PrePaymentHookConfig,
+  fallback = 'policy hook request failed'
+): string {
+  return err instanceof Error && err.name === 'AbortError'
+    ? `policy hook timed out after ${config.timeoutMs}ms`
+    : fallback;
+}
+
+function applyFailMode(config: PrePaymentHookConfig, detail: string): { attestation?: unknown } {
+  if (config.failMode === 'open') {
+    // Fail-open: allow the payment, but record the hook failure on stderr.
+    console.error(`[pre-payment-hook] fail-open: proceeding despite ${detail}`);
+    return {};
+  }
+  throw new PolicyDenied(
+    `Payment blocked by pre-payment policy hook (fail-closed): ${detail}`,
+    'policy_hook_unavailable'
+  );
+}

--- a/test/bolt11.test.js
+++ b/test/bolt11.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { bolt11AmountSats } = require('../dist/bolt11.js');
+
+// The body after the '1' separator is irrelevant to amount parsing; these use
+// short placeholder data parts. Only the HRP (ln<currency><amount>) matters.
+test('bolt11: decodes nano amounts', () => {
+  assert.equal(bolt11AmountSats('lnbc2500n1pjxyzqqdata'), 250);
+  assert.equal(bolt11AmountSats('lnbc1500n1pqdata'), 150);
+});
+
+test('bolt11: decodes micro and milli amounts', () => {
+  assert.equal(bolt11AmountSats('lnbc1u1pqdata'), 100); // 1e-6 BTC
+  assert.equal(bolt11AmountSats('lnbc20m1pqdata'), 2_000_000); // 0.02 BTC
+});
+
+test('bolt11: handles testnet and regtest prefixes', () => {
+  assert.equal(bolt11AmountSats('lntb500u1pqdata'), 50_000);
+  assert.equal(bolt11AmountSats('lnbcrt10u1pqdata'), 1_000);
+});
+
+test('bolt11: case-insensitive (bech32 may be upper-cased)', () => {
+  assert.equal(bolt11AmountSats('LNBC2500N1PJXYZQQDATA'), 250);
+});
+
+test('bolt11: amountless / unparseable / non-invoice -> null', () => {
+  assert.equal(bolt11AmountSats('lnbc1pqamountless'), null); // no digits before separator
+  assert.equal(bolt11AmountSats('not-an-invoice'), null);
+  assert.equal(bolt11AmountSats(''), null);
+  assert.equal(bolt11AmountSats('lnxx2500n1pqdata'), null); // unknown currency prefix
+});

--- a/test/client-hook.test.js
+++ b/test/client-hook.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+// Pin the LF API base BEFORE requiring the client (it reads the env at import).
+process.env.LIGHTNING_WALLET_API_URL = 'https://lf.test/api';
+
+const { test, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { LightningFaucetClient } = require('../dist/lightning-faucet.js');
+const { PolicyDenied } = require('../dist/pre-payment-hook.js');
+
+const API = 'https://lf.test/api';
+const HOOK = 'https://hook.test/policy';
+const realFetch = global.fetch;
+
+const jsonResponse = (obj, ok = true, status = 200) => ({ ok, status, json: async () => obj });
+
+afterEach(() => {
+  global.fetch = realFetch;
+  delete process.env.PRE_PAYMENT_HOOK_URL;
+  delete process.env.PRE_PAYMENT_HOOK_TIMEOUT_MS;
+  delete process.env.PRE_PAYMENT_HOOK_FAIL_MODE;
+});
+
+// Build a fetch stub. `hook` decides the hook response (or 'timeout'); records
+// whether the funds-moving LF payment action was ever sent.
+function stubFetch(hook) {
+  const state = { paymentExecuted: false, hookCalled: false };
+  global.fetch = async (url, opts) => {
+    if (url === HOOK) {
+      state.hookCalled = true;
+      if (hook === 'timeout') {
+        return new Promise((_, reject) => {
+          opts.signal.addEventListener('abort', () => {
+            const e = new Error('aborted'); e.name = 'AbortError'; reject(e);
+          });
+        });
+      }
+      return jsonResponse(hook);
+    }
+    // Otherwise it's the LF backend (single POST endpoint, action in the body).
+    const body = JSON.parse(opts.body);
+    if (body.action === 'whoami') return jsonResponse({ success: true, type: 'agent', id: 7 });
+    if (body.action === 'l402_pay') {
+      state.paymentExecuted = true;
+      return jsonResponse({ success: true, status_code: 200, body: '{"ok":true}' });
+    }
+    return jsonResponse({ success: true });
+  };
+  return state;
+}
+
+test('deny: l402Pay raises PolicyDenied and executes NO payment', async () => {
+  process.env.PRE_PAYMENT_HOOK_URL = HOOK;
+  const state = stubFetch({ decision: 'deny', reason: { code: 'over_limit', message: 'exceeds delegation ceiling' } });
+  const client = new LightningFaucetClient('test-key');
+
+  await assert.rejects(
+    () => client.l402Pay('https://api.example/paid', 'GET', undefined, 1000),
+    (err) => err instanceof PolicyDenied && err.code === 'over_limit'
+  );
+  assert.equal(state.paymentExecuted, false, 'payment must not execute on deny');
+  assert.equal(state.hookCalled, true);
+});
+
+test('allow: l402Pay proceeds and executes the payment', async () => {
+  process.env.PRE_PAYMENT_HOOK_URL = HOOK;
+  const state = stubFetch({ decision: 'allow' });
+  const client = new LightningFaucetClient('test-key');
+
+  const res = await client.l402Pay('https://api.example/paid', 'GET', undefined, 1000);
+  assert.equal(state.paymentExecuted, true);
+  assert.equal(res.statusCode, 200);
+});
+
+test('unconfigured: no hook call, payment proceeds unchanged', async () => {
+  // PRE_PAYMENT_HOOK_URL intentionally unset.
+  const state = stubFetch({ decision: 'deny' }); // would deny IF the hook were called
+  const client = new LightningFaucetClient('test-key');
+
+  await client.l402Pay('https://api.example/paid', 'GET', undefined, 1000);
+  assert.equal(state.hookCalled, false, 'hook must not be contacted when unconfigured');
+  assert.equal(state.paymentExecuted, true);
+});
+
+test('timeout: fail-closed denies and executes NO payment', async () => {
+  process.env.PRE_PAYMENT_HOOK_URL = HOOK;
+  process.env.PRE_PAYMENT_HOOK_TIMEOUT_MS = '50';
+  const state = stubFetch('timeout');
+  const client = new LightningFaucetClient('test-key');
+
+  await assert.rejects(
+    () => client.l402Pay('https://api.example/paid', 'GET', undefined, 1000),
+    (err) => err instanceof PolicyDenied && err.code === 'policy_hook_unavailable'
+  );
+  assert.equal(state.paymentExecuted, false);
+});
+
+test('proposal_id is unique per payment attempt', async () => {
+  process.env.PRE_PAYMENT_HOOK_URL = HOOK;
+  const ids = [];
+  global.fetch = async (url, opts) => {
+    if (url === HOOK) {
+      ids.push(JSON.parse(opts.body).proposal_id);
+      return jsonResponse({ decision: 'allow' });
+    }
+    const body = JSON.parse(opts.body);
+    if (body.action === 'whoami') return jsonResponse({ success: true, id: 7 });
+    return jsonResponse({ success: true, status_code: 200, body: '{}' });
+  };
+  const client = new LightningFaucetClient('test-key');
+  await client.l402Pay('https://api.example/a', 'GET', undefined, 1000);
+  await client.l402Pay('https://api.example/b', 'GET', undefined, 1000);
+  assert.equal(ids.length, 2);
+  assert.notEqual(ids[0], ids[1]);
+  assert.ok(ids[0] && ids[1]);
+});
+
+test('nostrZap is gated by the hook (deny blocks it, no payment)', async () => {
+  process.env.PRE_PAYMENT_HOOK_URL = HOOK;
+  let zapExecuted = false;
+  global.fetch = async (url, opts) => {
+    if (url === HOOK) return jsonResponse({ decision: 'deny', reason: { message: 'blocked' } });
+    const body = JSON.parse(opts.body);
+    if (body.action === 'whoami') return jsonResponse({ success: true, id: 7 });
+    if (body.action === 'nostr_zap') { zapExecuted = true; return jsonResponse({ success: true }); }
+    return jsonResponse({ success: true });
+  };
+  const client = new LightningFaucetClient('test-key');
+  await assert.rejects(() => client.nostrZap('alice@example.com', 500), (err) => err instanceof PolicyDenied);
+  assert.equal(zapExecuted, false);
+});
+
+test('keysend is also gated by the hook (deny blocks it)', async () => {
+  process.env.PRE_PAYMENT_HOOK_URL = HOOK;
+  const state = stubFetch({ decision: 'deny', reason: { message: 'blocked' } });
+  // Record keysend action separately.
+  const prev = global.fetch;
+  global.fetch = async (url, opts) => {
+    if (url !== HOOK) {
+      const body = JSON.parse(opts.body);
+      if (body.action === 'keysend') state.paymentExecuted = true;
+    }
+    return prev(url, opts);
+  };
+  const client = new LightningFaucetClient('test-key');
+
+  await assert.rejects(() => client.keysend('02abc', 500, 'hi'), (err) => err instanceof PolicyDenied);
+  assert.equal(state.paymentExecuted, false);
+});

--- a/test/pre-payment-hook.test.js
+++ b/test/pre-payment-hook.test.js
@@ -1,0 +1,130 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  getPrePaymentHookConfig,
+  runPrePaymentHook,
+  PolicyDenied,
+} = require('../dist/pre-payment-hook.js');
+
+// ---------------------------------------------------------------------------
+// getPrePaymentHookConfig
+// ---------------------------------------------------------------------------
+
+test('config: returns null when no hook URL is set', () => {
+  assert.equal(getPrePaymentHookConfig({}), null);
+  assert.equal(getPrePaymentHookConfig({ PRE_PAYMENT_HOOK_URL: '   ' }), null);
+});
+
+test('config: defaults timeout to 3000 and fail mode to closed', () => {
+  const cfg = getPrePaymentHookConfig({ PRE_PAYMENT_HOOK_URL: 'https://h' });
+  assert.deepEqual(cfg, { url: 'https://h', timeoutMs: 3000, failMode: 'closed' });
+});
+
+test('config: parses a valid timeout, falls back on invalid/non-positive', () => {
+  assert.equal(
+    getPrePaymentHookConfig({ PRE_PAYMENT_HOOK_URL: 'https://h', PRE_PAYMENT_HOOK_TIMEOUT_MS: '500' }).timeoutMs,
+    500
+  );
+  for (const bad of ['abc', '0', '-5', '']) {
+    assert.equal(
+      getPrePaymentHookConfig({ PRE_PAYMENT_HOOK_URL: 'https://h', PRE_PAYMENT_HOOK_TIMEOUT_MS: bad }).timeoutMs,
+      3000
+    );
+  }
+});
+
+test('config: fail mode open only when explicitly "open" (case-insensitive)', () => {
+  const open = (v) => getPrePaymentHookConfig({ PRE_PAYMENT_HOOK_URL: 'https://h', PRE_PAYMENT_HOOK_FAIL_MODE: v }).failMode;
+  assert.equal(open('open'), 'open');
+  assert.equal(open('OPEN'), 'open');
+  assert.equal(open('closed'), 'closed');
+  assert.equal(open('garbage'), 'closed');
+  assert.equal(open(undefined), 'closed');
+});
+
+// ---------------------------------------------------------------------------
+// runPrePaymentHook
+// ---------------------------------------------------------------------------
+
+const PROPOSAL = {
+  proposal_id: 'p1',
+  agent_id: 7,
+  protocol: 'l402',
+  destination_or_url: 'https://api.example/x',
+  amount_sats: null,
+  max_payment_sats: 1000,
+  method: 'GET',
+  ts: '2026-06-06T00:00:00.000Z',
+};
+
+const cfg = (over = {}) => ({ url: 'https://hook', timeoutMs: 1000, failMode: 'closed', ...over });
+const respond = (obj, ok = true, status = 200) => async () => ({ ok, status, json: async () => obj });
+
+test('hook: allow resolves and forwards the opaque attestation', async () => {
+  const out = await runPrePaymentHook(PROPOSAL, cfg(), {
+    fetchImpl: respond({ decision: 'allow', attestation: { token: 'abc' } }),
+  });
+  assert.deepEqual(out, { attestation: { token: 'abc' } });
+});
+
+test('hook: deny throws PolicyDenied carrying the structured reason', async () => {
+  await assert.rejects(
+    () => runPrePaymentHook(PROPOSAL, cfg(), {
+      fetchImpl: respond({ decision: 'deny', reason: { code: 'over_limit', message: 'exceeds ceiling' } }),
+    }),
+    (err) => {
+      assert.ok(err instanceof PolicyDenied);
+      assert.equal(err.code, 'over_limit');
+      assert.equal(err.reason.message, 'exceeds ceiling');
+      assert.match(err.message, /exceeds ceiling/);
+      return true;
+    }
+  );
+});
+
+test('hook: non-2xx denies under fail-closed and surfaces the status, proceeds under fail-open', async () => {
+  await assert.rejects(
+    () => runPrePaymentHook(PROPOSAL, cfg({ failMode: 'closed' }), { fetchImpl: respond({}, false, 503) }),
+    (err) => {
+      assert.ok(err instanceof PolicyDenied);
+      assert.equal(err.code, 'policy_hook_unavailable');
+      // Regression: the HTTP status must reach the error, not be swallowed and
+      // re-wrapped as a generic "request failed".
+      assert.match(err.message, /HTTP 503/);
+      return true;
+    }
+  );
+  const out = await runPrePaymentHook(PROPOSAL, cfg({ failMode: 'open' }), { fetchImpl: respond({}, false, 503) });
+  assert.deepEqual(out, {});
+});
+
+test('hook: transport/timeout error denies under fail-closed, proceeds under fail-open', async () => {
+  const abort = async () => { const e = new Error('aborted'); e.name = 'AbortError'; throw e; };
+  await assert.rejects(
+    () => runPrePaymentHook(PROPOSAL, cfg({ failMode: 'closed' }), { fetchImpl: abort }),
+    (err) => err instanceof PolicyDenied && err.code === 'policy_hook_unavailable'
+  );
+  const out = await runPrePaymentHook(PROPOSAL, cfg({ failMode: 'open' }), { fetchImpl: abort });
+  assert.deepEqual(out, {});
+});
+
+test('hook: malformed decision is treated as a hook error (fail-closed denies)', async () => {
+  await assert.rejects(
+    () => runPrePaymentHook(PROPOSAL, cfg(), { fetchImpl: respond({ decision: 'maybe' }) }),
+    (err) => err instanceof PolicyDenied
+  );
+});
+
+test('hook: proposal carries no api key / credentials', async () => {
+  let sentBody;
+  await runPrePaymentHook(PROPOSAL, cfg(), {
+    fetchImpl: async (_url, opts) => { sentBody = JSON.parse(opts.body); return { ok: true, status: 200, json: async () => ({ decision: 'allow' }) }; },
+  });
+  assert.deepEqual(Object.keys(sentBody).sort(), [
+    'agent_id', 'amount_sats', 'destination_or_url', 'max_payment_sats', 'method', 'proposal_id', 'protocol', 'ts',
+  ]);
+  assert.ok(!('api_key' in sentBody));
+});


### PR DESCRIPTION
# Add an optional, vendor-neutral pre-payment policy hook

## Why

[Observer Protocol](https://observerprotocol.org) is building agent-trust infrastructure on the Lightning rail — verifiable agent identity, scoped spending delegations, and signed policy evaluations. To make an autonomous agent's spending safe, we need to **check a proposed payment against a policy before it executes**, and abort it if the policy says no.

Rather than build anything Observer-specific into this client, this PR adds a **generic, opt-in hook**: any policy service that speaks a small JSON request/response contract can allow or deny a payment before it goes out. Observer Protocol points the hook at its policy engine (which evaluates the payment against the agent's signed delegation and returns a signed allow/deny), but nothing here depends on Observer — it's equally useful for a spending-limit service, an approval workflow, a compliance check, or a homemade rule.

## What

- New `PRE_PAYMENT_HOOK_URL` (+ `PRE_PAYMENT_HOOK_TIMEOUT_MS`, `PRE_PAYMENT_HOOK_FAIL_MODE`) configuration. **When unset, behaviour is completely unchanged** — there is no new dependency and no change to any existing code path.
- When configured, every **agent-initiated spend** (`pay_l402_api`, `pay_invoice`, `keysend`, `pay_lightning_address`, and Nostr zaps) POSTs a generic proposal to the hook first. On `allow` the payment proceeds; on `deny` it is aborted with a `PolicyDenied` error before any funds move. On hook error/timeout the configurable fail mode applies — **fail-closed by default**.
- The hook is enforced at the API-client layer, so it covers **both the MCP server and the `lw` CLI** from a single chokepoint.
- Operator-scoped fund management (withdrawals, agent funding, transfers) is intentionally **not** gated — those are operator actions, not agent spends.

## Design notes

- **No credentials leave the wallet.** The proposal contains only `proposal_id`, `agent_id`, `protocol`, `destination_or_url`, `amount_sats`, `max_payment_sats`, `method`, `ts`. The API key is never sent to the hook URL.
- **Exact amounts where knowable.** `keysend`/`lnaddress` send the exact amount; BOLT11 is decoded locally (no extra API call) to populate it; L402/X402 amounts are challenge-determined at execution time, so the hook enforces the authorised ceiling (`max_payment_sats`) up front.
- **No new dependencies.** Tests use the built-in `node:test` runner.

## Testing

`npm test` (builds, then runs `node --test`). Coverage: config parsing, allow/deny/timeout/fail-mode behaviour, the client-level guarantees (a `deny` executes **no** payment; an unset hook is a no-op; a fail-closed timeout blocks), BOLT11 amount decoding, and `proposal_id` uniqueness.

## Docs

New "Pre-Payment Policy Hook" section in the README documenting configuration, the exact request/response contract, what data leaves the wallet, and the coverage boundary.

---

*Happy to adjust the shape of the hook contract or the configuration surface to fit how you'd like to take this upstream.*
