### PR TITLE
feat: claim_promo + update_operator tools, keyless get_info (v1.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@
 
 **Give your AI agent a Bitcoin wallet.** MCP server + CLI. Works with Claude Code, OpenClaw, Cursor, and any agent framework.
 
+## What's New in v1.4
+
+- **`update_operator` tool / `lw set-email`** - set your operator email from the MCP client or CLI; a verification link is emailed to you.
+- **`claim_promo` tool / `lw claim-promo`** - claim the free-sats install promo directly from your agent. Requirements: verified email + operator account at least 24 hours old.
+- **`get_info` works before registration** - service info no longer requires an API key.
+
+### Free 100 sats for new operators
+
+1. `lw register --email you@example.com` (or the `register_operator` MCP tool with an email)
+2. Click the verification link we email you
+3. After your account is 24 hours old: `lw claim-promo` (or the `claim_promo` MCP tool)
+
+One bonus per operator, first 100 installs only, no deposit required.
+
 ## What's New in v1.3
 
 **v1.3.0** - L402 protocol v0 support per the latest Lightning Labs spec.
@@ -158,6 +172,9 @@ Then ask Claude: *"Register a new Lightning Wallet operator account"*
 | `get_deposit_invoice` | Create invoice to fund operator account |
 | `withdraw` | Withdraw funds to external Lightning destination |
 | `set_operator_key` | Switch to operator credentials |
+
+- `update_operator` - set operator email (sends verification link) and/or name
+- `claim_promo` - claim the free-sats install promo (verified email + 24h account)
 
 ### Agent Management
 

--- a/README.md
+++ b/README.md
@@ -6,18 +6,6 @@
 
 **Give your AI agent a Bitcoin wallet.** MCP server + CLI. Works with Claude Code, OpenClaw, Cursor, and any agent framework.
 
-> **Note:** This package was previously published as `lightning-faucet-mcp`. The functionality is identical.
-
-## Free Sats Promotion
-
-**First 100 installs get 100 free sats — one per person!**
-
-1. `npm i -g lightning-wallet-mcp`
-2. `lw register --name "YourAgent"`
-3. `lw deposit 100`
-
-We verify the invoice cryptographically and pay automatically. No trust required — the destination pubkey in the invoice proves it came from `lw`.
-
 ## What's New in v1.3
 
 **v1.3.0** - L402 protocol v0 support per the latest Lightning Labs spec.

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -10,7 +10,7 @@
  */
 Object.defineProperty(exports, "__esModule", { value: true });
 const lightning_faucet_js_1 = require("./lightning-faucet.js");
-const VERSION = '1.1.0';
+const VERSION = '1.4.0';
 // --- Helpers ---
 function getApiKey() {
     const key = process.env.LIGHTNING_WALLET_API_KEY;
@@ -256,9 +256,22 @@ async function cmdTransactions(flags) {
         has_more: result.has_more,
     };
 }
-async function cmdInfo() {
+async function cmdSetEmail(positional) {
+    const email = positional[0];
+    if (!email)
+        error('Usage: lw set-email <email>');
     const client = getClient();
-    const result = await client.getInfo();
+    return client.updateOperator({ email });
+}
+async function cmdClaimPromo() {
+    const client = getClient();
+    return client.claimPromo();
+}
+async function cmdInfo() {
+    // Service info is public - works with or without an API key
+    const result = process.env.LIGHTNING_WALLET_API_KEY
+        ? await getClient().getInfo()
+        : await (0, lightning_faucet_js_1.getPublicInfo)();
     return {
         version: result.version,
         api_version: result.apiVersion,
@@ -316,6 +329,9 @@ COMMANDS
   list-agents | agents             List all agents
 
   transactions                    Recent transactions [--limit 10] [--offset 0]
+  set-email <email>               Set operator email (verification link emailed)
+  claim-promo                     Claim the 100-sat install promo
+                                    (requires verified email + 24h account age)
   help                            Show this help
 
 WEBHOOKS
@@ -403,6 +419,12 @@ async function main() {
                 break;
             case 'transactions':
                 result = await cmdTransactions(flags);
+                break;
+            case 'set-email':
+                result = await cmdSetEmail(positional);
+                break;
+            case 'claim-promo':
+                result = await cmdClaimPromo();
                 break;
             case 'info':
                 result = await cmdInfo();

--- a/dist/index.js
+++ b/dist/index.js
@@ -338,7 +338,7 @@ server.setRequestHandler(types_js_1.ListToolsRequestSchema, async () => ({
                 type: 'object',
                 properties: {
                     name: { type: 'string', description: 'Name for the operator account (optional)' },
-                    email: { type: 'string', description: 'Optional email for product updates and feature announcements' },
+                    email: { type: 'string', description: 'Email address — strongly recommended for onboarding tips, setup help, and product updates. Without it we cannot reach you if there are issues.' },
                 },
                 required: [],
             },

--- a/dist/index.js
+++ b/dist/index.js
@@ -119,6 +119,13 @@ const FundAgentSchema = zod_1.z.object({
     amount_sats: zod_1.z.number().int().min(1).max(10_000_000).describe('Amount in satoshis to transfer'),
 });
 const ListAgentsSchema = zod_1.z.object({});
+const UpdateOperatorSchema = zod_1.z.object({
+    email: zod_1.z.string().email().optional(),
+    name: zod_1.z.string().min(1).max(100).optional(),
+});
+const ClaimPromoSchema = zod_1.z.object({
+    promo_code: zod_1.z.string().optional(),
+});
 const SetOperatorKeySchema = zod_1.z.object({
     api_key: zod_1.z.string().min(10, 'API key is too short').max(200, 'API key is too long')
         .describe('The operator API key to use for subsequent requests'),
@@ -339,6 +346,29 @@ server.setRequestHandler(types_js_1.ListToolsRequestSchema, async () => ({
                 properties: {
                     name: { type: 'string', description: 'Name for the operator account (optional)' },
                     email: { type: 'string', description: 'Email address — strongly recommended for onboarding tips, setup help, and product updates. Without it we cannot reach you if there are issues.' },
+                },
+                required: [],
+            },
+        },
+        {
+            name: 'update_operator',
+            description: 'Update operator profile: set your email (sends a verification link - required for the free-sats promo) and/or display name. REQUIRES OPERATOR KEY.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    email: { type: 'string', description: 'Email address to set. A verification link is emailed; click it to verify.' },
+                    name: { type: 'string', description: 'Display name for the operator account' },
+                },
+                required: [],
+            },
+        },
+        {
+            name: 'claim_promo',
+            description: 'Claim the free-sats install promo (100 sats, first 100 installs). Requires a verified email (set one with update_operator, then click the emailed link) and an operator account at least 24 hours old. REQUIRES OPERATOR KEY.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    promo_code: { type: 'string', description: "Promo code (default: 'first_100_installs')" },
                 },
                 required: [],
             },
@@ -943,6 +973,38 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                     ],
                 };
             }
+            case 'update_operator': {
+                const parsed = UpdateOperatorSchema.parse(args);
+                if (parsed.email === undefined && parsed.name === undefined) {
+                    throw new Error('Provide email and/or name to update.');
+                }
+                const result = await session.requireClient().updateOperator(parsed);
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify({
+                                success: result.success !== false,
+                                message: result.message || 'Operator updated',
+                                updated_fields: result.updated_fields,
+                                email_verification: result.email_verification,
+                            }, null, 2),
+                        },
+                    ],
+                };
+            }
+            case 'claim_promo': {
+                const parsed = ClaimPromoSchema.parse(args);
+                const result = await session.requireClient().claimPromo(parsed.promo_code);
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(result, null, 2),
+                        },
+                    ],
+                };
+            }
             case 'get_deposit_invoice': {
                 const parsed = GetDepositInvoiceSchema.parse(args);
                 const result = await session.requireClient().getDepositInvoice(parsed.amount_sats);
@@ -1263,7 +1325,15 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
             // ==========================================
             case 'get_info': {
                 GetInfoSchema.parse(args);
-                const result = await session.requireClient().getInfo();
+                // Service info is public - fall back to an unauthenticated request so
+                // first-run users can check the service before registering.
+                let result;
+                try {
+                    result = await session.requireClient().getInfo();
+                }
+                catch {
+                    result = await (0, lightning_faucet_js_1.getPublicInfo)();
+                }
                 return {
                     content: [
                         {

--- a/dist/lightning-faucet.d.ts
+++ b/dist/lightning-faucet.d.ts
@@ -513,10 +513,40 @@ export declare class LightningFaucetClient {
      * Vote on a post
      */
     boardVote(postId: number, direction: string): Promise<Record<string, unknown>>;
+    /**
+     * Update operator profile (email and/or name). Setting an email sends a
+     * verification link - a verified email is required for the free-sats promo.
+     */
+    updateOperator(opts: {
+        email?: string;
+        name?: string;
+    }): Promise<ApiResponse & {
+        message?: string;
+        updated_fields?: string[];
+        email_verification?: string;
+    }>;
+    /**
+     * Claim a promo bonus (default: the first_100_installs free-sats promo).
+     * Requires a verified email and an operator account at least 24 hours old.
+     */
+    claimPromo(promoCode?: string): Promise<ApiResponse & {
+        promo?: string;
+        bonus_sats?: number;
+        message?: string;
+    }>;
 }
 export declare function registerOperator(name?: string, email?: string): Promise<{
     operatorId: number;
     apiKey: string;
     recoveryCode: string;
+}>;
+export declare function getPublicInfo(): Promise<{
+    version: string;
+    apiVersion: string;
+    status: string;
+    maxPaymentSats: number;
+    minPaymentSats: number;
+    supportedFeatures: string[];
+    rawResponse: ApiResponse;
 }>;
 export {};

--- a/dist/lightning-faucet.js
+++ b/dist/lightning-faucet.js
@@ -7,6 +7,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.LightningFaucetClient = void 0;
 exports.registerOperator = registerOperator;
+exports.getPublicInfo = getPublicInfo;
 const API_BASE_URL = process.env.LIGHTNING_WALLET_API_URL || 'https://lightningfaucet.com/ai-agents/api';
 class LightningFaucetClient {
     apiKey;
@@ -774,6 +775,28 @@ class LightningFaucetClient {
             direction,
         });
     }
+    /**
+     * Update operator profile (email and/or name). Setting an email sends a
+     * verification link - a verified email is required for the free-sats promo.
+     */
+    async updateOperator(opts) {
+        const params = {};
+        if (opts.email !== undefined)
+            params.email = opts.email;
+        if (opts.name !== undefined)
+            params.name = opts.name;
+        return this.request('update_operator', params);
+    }
+    /**
+     * Claim a promo bonus (default: the first_100_installs free-sats promo).
+     * Requires a verified email and an operator account at least 24 hours old.
+     */
+    async claimPromo(promoCode) {
+        const params = {};
+        if (promoCode)
+            params.promo_code = promoCode;
+        return this.request('claim_promo', params);
+    }
 }
 exports.LightningFaucetClient = LightningFaucetClient;
 // Static method for registration (no API key needed)
@@ -806,5 +829,26 @@ async function registerOperator(name, email) {
         operatorId: result.operator_id || 0,
         apiKey: result.api_key,
         recoveryCode: result.recovery_code || '',
+    };
+}
+// Public service info (no API key needed)
+async function getPublicInfo() {
+    const response = await fetch(API_BASE_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'get_info' }),
+    });
+    if (!response.ok) {
+        throw new Error(`Request failed (HTTP ${response.status})`);
+    }
+    const result = (await response.json());
+    return {
+        version: result.version || '2.0.0',
+        apiVersion: result.api_version || '1.0',
+        status: result.status || 'operational',
+        maxPaymentSats: result.max_payment_sats || 1000000,
+        minPaymentSats: result.min_payment_sats || 1,
+        supportedFeatures: result.supported_features || ['l402', 'webhooks', 'lightning_address'],
+        rawResponse: result,
     };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-wallet-mcp",
-  "version": "1.3.0",
+  "version": "1.3.2",
   "mcpName": "io.github.lightningfaucet/lightning-wallet-mcp",
   "description": "Lightning wallet for AI agents. MCP server + CLI. Works with Claude Code, OpenClaw, Cursor, and any agent framework.",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightning-wallet-mcp",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "mcpName": "io.github.lightningfaucet/lightning-wallet-mcp",
   "description": "Lightning wallet for AI agents. MCP server + CLI. Works with Claude Code, OpenClaw, Cursor, and any agent framework.",
   "main": "dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,9 +9,9 @@
  * Usage: lw <command> [options]
  */
 
-import { LightningFaucetClient, registerOperator } from './lightning-faucet.js';
+import { LightningFaucetClient, registerOperator, getPublicInfo } from './lightning-faucet.js';
 
-const VERSION = '1.1.0';
+const VERSION = '1.4.0';
 
 // --- Helpers ---
 
@@ -262,9 +262,24 @@ async function cmdTransactions(flags: Record<string, string | boolean>): Promise
   };
 }
 
-async function cmdInfo(): Promise<unknown> {
+
+async function cmdSetEmail(positional: string[]): Promise<unknown> {
+  const email = positional[0];
+  if (!email) error('Usage: lw set-email <email>');
   const client = getClient();
-  const result = await client.getInfo();
+  return client.updateOperator({ email });
+}
+
+async function cmdClaimPromo(): Promise<unknown> {
+  const client = getClient();
+  return client.claimPromo();
+}
+
+async function cmdInfo(): Promise<unknown> {
+  // Service info is public - works with or without an API key
+  const result = process.env.LIGHTNING_WALLET_API_KEY
+    ? await getClient().getInfo()
+    : await getPublicInfo();
   return {
     version: result.version,
     api_version: result.apiVersion,
@@ -323,6 +338,9 @@ COMMANDS
   list-agents | agents             List all agents
 
   transactions                    Recent transactions [--limit 10] [--offset 0]
+  set-email <email>               Set operator email (verification link emailed)
+  claim-promo                     Claim the 100-sat install promo
+                                    (requires verified email + 24h account age)
   help                            Show this help
 
 WEBHOOKS
@@ -415,6 +433,12 @@ async function main(): Promise<void> {
         break;
       case 'transactions':
         result = await cmdTransactions(flags);
+        break;
+      case 'set-email':
+        result = await cmdSetEmail(positional);
+        break;
+      case 'claim-promo':
+        result = await cmdClaimPromo();
         break;
       case 'info':
         result = await cmdInfo();

--- a/src/index.ts
+++ b/src/index.ts
@@ -395,7 +395,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         type: 'object',
         properties: {
           name: { type: 'string', description: 'Name for the operator account (optional)' },
-          email: { type: 'string', description: 'Optional email for product updates and feature announcements' },
+          email: { type: 'string', description: 'Email address — strongly recommended for onboarding tips, setup help, and product updates. Without it we cannot reach you if there are issues.' },
         },
         required: [],
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
-import { LightningFaucetClient, registerOperator } from './lightning-faucet.js';
+import { LightningFaucetClient, registerOperator, getPublicInfo } from './lightning-faucet.js';
 
 /**
  * Session state manager for the MCP server.
@@ -143,6 +143,15 @@ const FundAgentSchema = z.object({
 });
 
 const ListAgentsSchema = z.object({});
+
+const UpdateOperatorSchema = z.object({
+  email: z.string().email().optional(),
+  name: z.string().min(1).max(100).optional(),
+});
+
+const ClaimPromoSchema = z.object({
+  promo_code: z.string().optional(),
+});
 
 const SetOperatorKeySchema = z.object({
   api_key: z.string().min(10, 'API key is too short').max(200, 'API key is too long')
@@ -396,6 +405,29 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         properties: {
           name: { type: 'string', description: 'Name for the operator account (optional)' },
           email: { type: 'string', description: 'Email address — strongly recommended for onboarding tips, setup help, and product updates. Without it we cannot reach you if there are issues.' },
+        },
+        required: [],
+      },
+    },
+    {
+      name: 'update_operator',
+      description: 'Update operator profile: set your email (sends a verification link - required for the free-sats promo) and/or display name. REQUIRES OPERATOR KEY.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          email: { type: 'string', description: 'Email address to set. A verification link is emailed; click it to verify.' },
+          name: { type: 'string', description: 'Display name for the operator account' },
+        },
+        required: [],
+      },
+    },
+    {
+      name: 'claim_promo',
+      description: 'Claim the free-sats install promo (100 sats, first 100 installs). Requires a verified email (set one with update_operator, then click the emailed link) and an operator account at least 24 hours old. REQUIRES OPERATOR KEY.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          promo_code: { type: 'string', description: "Promo code (default: 'first_100_installs')" },
         },
         required: [],
       },
@@ -1014,6 +1046,40 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
+      case 'update_operator': {
+        const parsed = UpdateOperatorSchema.parse(args);
+        if (parsed.email === undefined && parsed.name === undefined) {
+          throw new Error('Provide email and/or name to update.');
+        }
+        const result = await session.requireClient().updateOperator(parsed);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: result.success !== false,
+                message: result.message || 'Operator updated',
+                updated_fields: result.updated_fields,
+                email_verification: result.email_verification,
+              }, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'claim_promo': {
+        const parsed = ClaimPromoSchema.parse(args);
+        const result = await session.requireClient().claimPromo(parsed.promo_code);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
       case 'get_deposit_invoice': {
         const parsed = GetDepositInvoiceSchema.parse(args);
         const result = await session.requireClient().getDepositInvoice(parsed.amount_sats);
@@ -1354,7 +1420,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // ==========================================
       case 'get_info': {
         GetInfoSchema.parse(args);
-        const result = await session.requireClient().getInfo();
+        // Service info is public - fall back to an unauthenticated request so
+        // first-run users can check the service before registering.
+        let result;
+        try {
+          result = await session.requireClient().getInfo();
+        } catch {
+          result = await getPublicInfo();
+        }
         return {
           content: [
             {

--- a/src/lightning-faucet.ts
+++ b/src/lightning-faucet.ts
@@ -1418,6 +1418,35 @@ export class LightningFaucetClient {
       direction,
     });
   }
+
+  /**
+   * Update operator profile (email and/or name). Setting an email sends a
+   * verification link - a verified email is required for the free-sats promo.
+   */
+  async updateOperator(opts: { email?: string; name?: string }): Promise<ApiResponse & {
+    message?: string;
+    updated_fields?: string[];
+    email_verification?: string;
+  }> {
+    const params: Record<string, unknown> = {};
+    if (opts.email !== undefined) params.email = opts.email;
+    if (opts.name !== undefined) params.name = opts.name;
+    return this.request('update_operator', params);
+  }
+
+  /**
+   * Claim a promo bonus (default: the first_100_installs free-sats promo).
+   * Requires a verified email and an operator account at least 24 hours old.
+   */
+  async claimPromo(promoCode?: string): Promise<ApiResponse & {
+    promo?: string;
+    bonus_sats?: number;
+    message?: string;
+  }> {
+    const params: Record<string, unknown> = {};
+    if (promoCode) params.promo_code = promoCode;
+    return this.request('claim_promo', params);
+  }
 }
 
 // Static method for registration (no API key needed)
@@ -1460,5 +1489,43 @@ export async function registerOperator(name?: string, email?: string): Promise<{
     operatorId: result.operator_id || 0,
     apiKey: result.api_key,
     recoveryCode: result.recovery_code || '',
+  };
+}
+
+
+// Public service info (no API key needed)
+export async function getPublicInfo(): Promise<{
+  version: string;
+  apiVersion: string;
+  status: string;
+  maxPaymentSats: number;
+  minPaymentSats: number;
+  supportedFeatures: string[];
+  rawResponse: ApiResponse;
+}> {
+  const response = await fetch(API_BASE_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action: 'get_info' }),
+  });
+  if (!response.ok) {
+    throw new Error(`Request failed (HTTP ${response.status})`);
+  }
+  const result = (await response.json()) as ApiResponse & {
+    version?: string;
+    api_version?: string;
+    status?: string;
+    max_payment_sats?: number;
+    min_payment_sats?: number;
+    supported_features?: string[];
+  };
+  return {
+    version: result.version || '2.0.0',
+    apiVersion: result.api_version || '1.0',
+    status: result.status || 'operational',
+    maxPaymentSats: result.max_payment_sats || 1000000,
+    minPaymentSats: result.min_payment_sats || 1,
+    supportedFeatures: result.supported_features || ['l402', 'webhooks', 'lightning_address'],
+    rawResponse: result,
   };
 }


### PR DESCRIPTION
Makes the 100-sat install promo actually claimable from MCP/CLI clients (the documented flow referenced tools that did not exist). Adds update_operator (email set + verification trigger), claim_promo, and keyless get_info. Smoke-tested against production API: set-email sends verification, claim-promo wiring confirmed (correct server-side rejection for already-claimed operator), keyless info returns service data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)