### PR TITLE
feat(register): surface the 100-sats promo on register_operator email

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 ## What's New in v1.4
 
 - **`update_operator` tool / `lw set-email`** - set your operator email from the MCP client or CLI; a verification link is emailed to you.
-- **`claim_promo` tool / `lw claim-promo`** - claim the free-sats install promo directly from your agent. Requirements: verified email + operator account at least 24 hours old.
+- **`claim_promo` tool / `lw claim-promo`** - claim the free-sats install promo directly from your agent. Requirements: verified email + operator account at least 3 hours old.
 - **`get_info` works before registration** - service info no longer requires an API key.
 
 ### Free 100 sats for new operators
 
 1. `lw register --email you@example.com` (or the `register_operator` MCP tool with an email)
 2. Click the verification link we email you
-3. After your account is 24 hours old: `lw claim-promo` (or the `claim_promo` MCP tool)
+3. After your account is 3 hours old: `lw claim-promo` (or the `claim_promo` MCP tool)
 
 One bonus per operator, first 100 installs only, no deposit required.
 
@@ -174,7 +174,7 @@ Then ask Claude: *"Register a new Lightning Wallet operator account"*
 | `set_operator_key` | Switch to operator credentials |
 
 - `update_operator` - set operator email (sends verification link) and/or name
-- `claim_promo` - claim the free-sats install promo (verified email + 24h account)
+- `claim_promo` - claim the free-sats install promo (verified email + 3h account)
 
 ### Agent Management
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -340,7 +340,7 @@ COMMANDS
   transactions                    Recent transactions [--limit 10] [--offset 0]
   set-email <email>               Set operator email (verification link emailed)
   claim-promo                     Claim the 100-sat install promo
-                                    (requires verified email + 24h account age)
+                                    (requires verified email + 3h account age)
   help                            Show this help
 
 WEBHOOKS

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,7 +124,7 @@ const GetTransactionsSchema = z.object({
 // Operator management schemas
 const RegisterOperatorSchema = z.object({
   name: z.string().optional().describe('Name for the operator account'),
-  email: z.string().email().optional().describe('Optional email for product updates and announcements'),
+  email: z.string().email().optional().describe('Your email — register WITH it to claim the 100 free-sats install promo. A verification link is sent; once verified, claim_promo funds your wallet. Strongly recommended.'),
 });
 
 const GetDepositInvoiceSchema = z.object({
@@ -399,12 +399,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     // Operator management tools
     {
       name: 'register_operator',
-      description: 'Register a new operator account. Returns API key and recovery code. SAVE THESE - they cannot be retrieved later!',
+      description: 'Register a new operator account. Returns API key and recovery code. SAVE THESE - they cannot be retrieved later! Tip: pass an email to claim the 100 free-sats install promo.',
       inputSchema: {
         type: 'object',
         properties: {
           name: { type: 'string', description: 'Name for the operator account (optional)' },
-          email: { type: 'string', description: 'Email address — strongly recommended for onboarding tips, setup help, and product updates. Without it we cannot reach you if there are issues.' },
+          email: { type: 'string', description: 'Email address — pass it here to claim the 100 free-sats install promo (a verification link is sent; once verified, call claim_promo to get funded). Also used for onboarding tips and important account notices.' },
         },
         required: [],
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -404,7 +404,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         type: 'object',
         properties: {
           name: { type: 'string', description: 'Name for the operator account (optional)' },
-          email: { type: 'string', description: 'Email address — pass it here to claim the 100 free-sats install promo (a verification link is sent; once verified, call claim_promo to get funded). Also used for onboarding tips and important account notices.' },
+          email: { type: 'string', description: 'Email address — pass it here to claim the 100 free-sats install promo (a verification link is sent; once verified, and once the operator account is at least 24 hours old, call claim_promo to get funded). Also used for onboarding tips and important account notices.' },
         },
         required: [],
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -404,7 +404,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         type: 'object',
         properties: {
           name: { type: 'string', description: 'Name for the operator account (optional)' },
-          email: { type: 'string', description: 'Email address — pass it here to claim the 100 free-sats install promo (a verification link is sent; once verified, and once the operator account is at least 24 hours old, call claim_promo to get funded). Also used for onboarding tips and important account notices.' },
+          email: { type: 'string', description: 'Email address — pass it here to claim the 100 free-sats install promo (a verification link is sent; once verified, and once the operator account is at least 3 hours old, call claim_promo to get funded). Also used for onboarding tips and important account notices.' },
         },
         required: [],
       },
@@ -423,7 +423,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
     },
     {
       name: 'claim_promo',
-      description: 'Claim the free-sats install promo (100 sats, first 100 installs). Requires a verified email (set one with update_operator, then click the emailed link) and an operator account at least 24 hours old. REQUIRES OPERATOR KEY.',
+      description: 'Claim the free-sats install promo (100 sats, first 100 installs). Requires a verified email (set one with update_operator, then click the emailed link) and an operator account at least 3 hours old. REQUIRES OPERATOR KEY.',
       inputSchema: {
         type: 'object',
         properties: {

--- a/src/lightning-faucet.ts
+++ b/src/lightning-faucet.ts
@@ -1436,7 +1436,7 @@ export class LightningFaucetClient {
 
   /**
    * Claim a promo bonus (default: the first_100_installs free-sats promo).
-   * Requires a verified email and an operator account at least 24 hours old.
+   * Requires a verified email and an operator account at least 3 hours old.
    */
   async claimPromo(promoCode?: string): Promise<ApiResponse & {
     promo?: string;


### PR DESCRIPTION
Half of operators register with no email → can never qualify for the promo. The `register_operator` email field only said "product updates", giving no reason to include it. This rewords the schema + tool description so a dev or an LLM sees that passing email at register is how you claim the 100 free-sats promo (verify → `claim_promo`).

Non-breaking: email stays optional, description-only change. Pairs with the 24h→3h cooldown drop + the promo-page copy fix on the site side.

**Needs your npm publish to take effect** (npx fetches latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)