### PR TITLE
fix: accept real BOLT11 invoices + tolerate omitted MCP args

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -85,7 +85,7 @@ const PayL402ApiSchema = zod_1.z.object({
         .describe('Maximum amount in satoshis to pay for this request'),
 });
 const PayInvoiceSchema = zod_1.z.object({
-    bolt11: zod_1.z.string().regex(/^ln(bc|tb|bcrt)1[a-z0-9]+$/i, 'Invalid BOLT11 invoice format')
+    bolt11: zod_1.z.string().regex(/^ln(bc|tb|bcrt)([0-9]+[munp]?)?1[a-z0-9]+$/i, 'Invalid BOLT11 invoice format')
         .describe('BOLT11 invoice string to pay (starts with lnbc...)'),
     max_fee_sats: zod_1.z.number().min(0).optional()
         .describe('Maximum routing fee in satoshis (default: 10% of invoice amount)'),
@@ -98,7 +98,7 @@ const GetInvoiceStatusSchema = zod_1.z.object({
     payment_hash: zod_1.z.string().describe('Payment hash of the invoice to check'),
 });
 const GetTransactionsSchema = zod_1.z.object({
-    limit: zod_1.z.number().min(1).max(200).default(50).describe('Max transactions to return'),
+    limit: zod_1.z.number().min(1).max(100).default(50).describe('Max transactions to return'),
     offset: zod_1.z.number().min(0).default(0).describe('Number to skip for pagination'),
 });
 // Operator management schemas
@@ -173,13 +173,13 @@ const RotateApiKeySchema = zod_1.z.object({
 // Tier 2 schemas
 const GetInfoSchema = zod_1.z.object({});
 const DecodeInvoiceSchema = zod_1.z.object({
-    bolt11: zod_1.z.string().regex(/^ln(bc|tb|bcrt)1[a-z0-9]+$/i, 'Invalid BOLT11 invoice format')
+    bolt11: zod_1.z.string().regex(/^ln(bc|tb|bcrt)([0-9]+[munp]?)?1[a-z0-9]+$/i, 'Invalid BOLT11 invoice format')
         .describe('BOLT11 invoice string to decode'),
 });
 const GetRateLimitsSchema = zod_1.z.object({});
 // Tier 3 schemas
 const WithdrawSchema = zod_1.z.object({
-    invoice: zod_1.z.string().regex(/^ln(bc|tb|bcrt)1[a-z0-9]+$/i, 'Invalid BOLT11 invoice format')
+    invoice: zod_1.z.string().regex(/^ln(bc|tb|bcrt)([0-9]+[munp]?)?1[a-z0-9]+$/i, 'Invalid BOLT11 invoice format')
         .describe('BOLT11 invoice to pay out to'),
 });
 const SweepAgentSchema = zod_1.z.object({
@@ -822,7 +822,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
     try {
         switch (name) {
             case 'check_balance': {
-                CheckBalanceSchema.parse(args);
+                CheckBalanceSchema.parse(args ?? {});
                 const result = await session.requireClient().checkBalance();
                 return {
                     content: [
@@ -838,7 +838,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'pay_l402_api': {
-                const parsed = PayL402ApiSchema.parse(args);
+                const parsed = PayL402ApiSchema.parse(args ?? {});
                 const result = await session.requireClient().l402Pay(parsed.url, parsed.method, parsed.body, parsed.max_payment_sats);
                 // Determine if the target returned a success response
                 const targetSuccess = result.statusCode >= 200 && result.statusCode < 300;
@@ -870,7 +870,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'pay_invoice': {
-                const parsed = PayInvoiceSchema.parse(args);
+                const parsed = PayInvoiceSchema.parse(args ?? {});
                 const result = await session.requireClient().payInvoice(parsed.bolt11, parsed.max_fee_sats);
                 return {
                     content: [
@@ -892,7 +892,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'create_invoice': {
-                const parsed = CreateInvoiceSchema.parse(args);
+                const parsed = CreateInvoiceSchema.parse(args ?? {});
                 const result = await session.requireClient().createInvoice(parsed.amount_sats, parsed.memo);
                 const invoiceResponse = {
                     success: true,
@@ -914,7 +914,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'get_invoice_status': {
-                const parsed = GetInvoiceStatusSchema.parse(args);
+                const parsed = GetInvoiceStatusSchema.parse(args ?? {});
                 const result = await session.requireClient().getInvoiceStatus(parsed.payment_hash);
                 return {
                     content: [
@@ -934,7 +934,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'get_transactions': {
-                const parsed = GetTransactionsSchema.parse(args);
+                const parsed = GetTransactionsSchema.parse(args ?? {});
                 const result = await session.requireClient().getTransactions(parsed.limit, parsed.offset);
                 return {
                     content: [
@@ -952,7 +952,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
             }
             // Operator management tool handlers
             case 'register_operator': {
-                const parsed = RegisterOperatorSchema.parse(args);
+                const parsed = RegisterOperatorSchema.parse(args ?? {});
                 const result = await (0, lightning_faucet_js_1.registerOperator)(parsed.name, parsed.email);
                 // Auto-set credentials so subsequent requests use the new operator key
                 session.setClient(new lightning_faucet_js_1.LightningFaucetClient(result.apiKey));
@@ -974,7 +974,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'update_operator': {
-                const parsed = UpdateOperatorSchema.parse(args);
+                const parsed = UpdateOperatorSchema.parse(args ?? {});
                 if (parsed.email === undefined && parsed.name === undefined) {
                     throw new Error('Provide email and/or name to update.');
                 }
@@ -994,7 +994,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'claim_promo': {
-                const parsed = ClaimPromoSchema.parse(args);
+                const parsed = ClaimPromoSchema.parse(args ?? {});
                 const result = await session.requireClient().claimPromo(parsed.promo_code);
                 return {
                     content: [
@@ -1006,7 +1006,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'get_deposit_invoice': {
-                const parsed = GetDepositInvoiceSchema.parse(args);
+                const parsed = GetDepositInvoiceSchema.parse(args ?? {});
                 const result = await session.requireClient().getDepositInvoice(parsed.amount_sats);
                 return {
                     content: [
@@ -1026,7 +1026,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'create_agent': {
-                const parsed = CreateAgentSchema.parse(args);
+                const parsed = CreateAgentSchema.parse(args ?? {});
                 const result = await session.requireClient().createAgent(parsed.name, parsed.description, parsed.budget_limit_sats);
                 return {
                     content: [
@@ -1044,7 +1044,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'fund_agent': {
-                const parsed = FundAgentSchema.parse(args);
+                const parsed = FundAgentSchema.parse(args ?? {});
                 const result = await session.requireClient().fundAgent(parsed.agent_id, parsed.amount_sats);
                 return {
                     content: [
@@ -1062,7 +1062,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'list_agents': {
-                ListAgentsSchema.parse(args);
+                ListAgentsSchema.parse(args ?? {});
                 const result = await session.requireClient().listAgents();
                 return {
                     content: [
@@ -1078,7 +1078,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'set_operator_key': {
-                const parsed = SetOperatorKeySchema.parse(args);
+                const parsed = SetOperatorKeySchema.parse(args ?? {});
                 session.setClient(new lightning_faucet_js_1.LightningFaucetClient(parsed.api_key));
                 return {
                     content: [
@@ -1093,7 +1093,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'set_agent_credentials': {
-                const parsed = SetAgentCredentialsSchema.parse(args);
+                const parsed = SetAgentCredentialsSchema.parse(args ?? {});
                 session.setClient(new lightning_faucet_js_1.LightningFaucetClient(parsed.api_key));
                 return {
                     content: [
@@ -1108,7 +1108,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'whoami': {
-                WhoamiSchema.parse(args);
+                WhoamiSchema.parse(args ?? {});
                 const result = await session.requireClient().whoami();
                 const response = {
                     success: true,
@@ -1137,7 +1137,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
             // TIER 1: Webhook Management
             // ==========================================
             case 'register_webhook': {
-                const parsed = RegisterWebhookSchema.parse(args);
+                const parsed = RegisterWebhookSchema.parse(args ?? {});
                 const result = await session.requireClient().registerWebhook(parsed.url, parsed.events);
                 return {
                     content: [
@@ -1156,7 +1156,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'list_webhooks': {
-                ListWebhooksSchema.parse(args);
+                ListWebhooksSchema.parse(args ?? {});
                 const result = await session.requireClient().listWebhooks();
                 return {
                     content: [
@@ -1172,7 +1172,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'delete_webhook': {
-                const parsed = DeleteWebhookSchema.parse(args);
+                const parsed = DeleteWebhookSchema.parse(args ?? {});
                 const result = await session.requireClient().deleteWebhook(parsed.webhook_id);
                 return {
                     content: [
@@ -1187,7 +1187,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'test_webhook': {
-                const parsed = TestWebhookSchema.parse(args);
+                const parsed = TestWebhookSchema.parse(args ?? {});
                 const result = await session.requireClient().testWebhook(parsed.webhook_id);
                 return {
                     content: [
@@ -1206,7 +1206,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
             // TIER 1: Budget Management
             // ==========================================
             case 'get_budget_status': {
-                const parsed = GetBudgetStatusSchema.parse(args);
+                const parsed = GetBudgetStatusSchema.parse(args ?? {});
                 const result = await session.requireClient().getBudgetStatus(parsed.agent_id);
                 return {
                     content: [
@@ -1225,7 +1225,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'set_budget': {
-                const parsed = SetBudgetSchema.parse(args);
+                const parsed = SetBudgetSchema.parse(args ?? {});
                 const result = await session.requireClient().setBudget(parsed.agent_id, parsed.budget_limit_sats);
                 return {
                     content: [
@@ -1245,7 +1245,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
             // TIER 1: Agent Lifecycle
             // ==========================================
             case 'deactivate_agent': {
-                const parsed = DeactivateAgentSchema.parse(args);
+                const parsed = DeactivateAgentSchema.parse(args ?? {});
                 const result = await session.requireClient().deactivateAgent(parsed.agent_id);
                 return {
                     content: [
@@ -1261,7 +1261,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'reactivate_agent': {
-                const parsed = ReactivateAgentSchema.parse(args);
+                const parsed = ReactivateAgentSchema.parse(args ?? {});
                 const result = await session.requireClient().reactivateAgent(parsed.agent_id);
                 return {
                     content: [
@@ -1280,7 +1280,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
             // TIER 1: Recovery & Key Rotation
             // ==========================================
             case 'recover_account': {
-                const parsed = RecoverAccountSchema.parse(args);
+                const parsed = RecoverAccountSchema.parse(args ?? {});
                 // Recovery doesn't need an existing API key — recoverAccount() uses its own fetch
                 const tempClient = session.getClient() || new lightning_faucet_js_1.LightningFaucetClient('recovery-placeholder');
                 const result = await tempClient.recoverAccount(parsed.recovery_code);
@@ -1302,7 +1302,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'rotate_api_key': {
-                const parsed = RotateApiKeySchema.parse(args);
+                const parsed = RotateApiKeySchema.parse(args ?? {});
                 const result = await session.requireClient().rotateApiKey(parsed.agent_id);
                 // Auto-switch to the new key
                 session.setClient(new lightning_faucet_js_1.LightningFaucetClient(result.apiKey));
@@ -1324,7 +1324,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
             // TIER 2: Service Info & Invoice Decoding
             // ==========================================
             case 'get_info': {
-                GetInfoSchema.parse(args);
+                GetInfoSchema.parse(args ?? {});
                 // Service info is public - fall back to an unauthenticated request so
                 // first-run users can check the service before registering.
                 let result;
@@ -1352,7 +1352,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'decode_invoice': {
-                const parsed = DecodeInvoiceSchema.parse(args);
+                const parsed = DecodeInvoiceSchema.parse(args ?? {});
                 const result = await session.requireClient().decodeInvoice(parsed.bolt11);
                 return {
                     content: [
@@ -1373,7 +1373,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'get_rate_limits': {
-                GetRateLimitsSchema.parse(args);
+                GetRateLimitsSchema.parse(args ?? {});
                 const result = await session.requireClient().getRateLimits();
                 return {
                     content: [
@@ -1393,7 +1393,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
             // TIER 3: Withdrawals & Advanced Payments
             // ==========================================
             case 'withdraw': {
-                const parsed = WithdrawSchema.parse(args);
+                const parsed = WithdrawSchema.parse(args ?? {});
                 const result = await session.requireClient().withdraw(parsed.invoice);
                 return {
                     content: [
@@ -1414,9 +1414,9 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'create_withdraw_link': {
-                const amountSats = args && typeof args === 'object' && 'amount_sats' in args
-                    ? args.amount_sats
-                    : undefined;
+                const { amount_sats: amountSats } = zod_1.z.object({
+                    amount_sats: zod_1.z.coerce.number().int().min(100).optional(),
+                }).parse(args ?? {});
                 const result = await session.requireClient().createWithdrawLink(amountSats);
                 return {
                     content: [
@@ -1439,7 +1439,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'sweep_agent': {
-                const parsed = SweepAgentSchema.parse(args);
+                const parsed = SweepAgentSchema.parse(args ?? {});
                 const amount = typeof parsed.amount_sats === 'string' ? 999999999 : parsed.amount_sats;
                 const result = await session.requireClient().sweepAgent(parsed.agent_id, amount);
                 return {
@@ -1458,7 +1458,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'pay_lightning_address': {
-                const parsed = PayLightningAddressSchema.parse(args);
+                const parsed = PayLightningAddressSchema.parse(args ?? {});
                 const result = await session.requireClient().payLightningAddress(parsed.address, parsed.amount_sats, parsed.comment);
                 return {
                     content: [
@@ -1480,7 +1480,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
             // NOSTR IDENTITY & ZAPS
             // ==========================================
             case 'set_nostr_identity': {
-                const parsed = SetNostrIdentitySchema.parse(args);
+                const parsed = SetNostrIdentitySchema.parse(args ?? {});
                 const result = await session.requireClient().setNostrIdentity(parsed.private_key);
                 return {
                     content: [
@@ -1513,7 +1513,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'nostr_zap': {
-                const parsed = NostrZapSchema.parse(args);
+                const parsed = NostrZapSchema.parse(args ?? {});
                 const result = await session.requireClient().nostrZap(parsed.address, parsed.amount_sats, parsed.recipient_pubkey, parsed.content, parsed.event_id, parsed.relays);
                 return {
                     content: [
@@ -1537,7 +1537,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
             // TIER 4: Advanced Agent Management
             // ==========================================
             case 'transfer_to_agent': {
-                const parsed = TransferToAgentSchema.parse(args);
+                const parsed = TransferToAgentSchema.parse(args ?? {});
                 const result = await session.requireClient().transferToAgent(parsed.to_agent_id, parsed.amount_sats, parsed.from_agent_id);
                 return {
                     content: [
@@ -1555,7 +1555,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'delete_agent': {
-                const parsed = DeleteAgentSchema.parse(args);
+                const parsed = DeleteAgentSchema.parse(args ?? {});
                 if (!parsed.confirm) {
                     return {
                         content: [
@@ -1588,7 +1588,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
             // TIER 5: Protocol Extensions
             // ==========================================
             case 'lnurl_auth': {
-                const parsed = LnurlAuthSchema.parse(args);
+                const parsed = LnurlAuthSchema.parse(args ?? {});
                 const result = await session.requireClient().lnurlAuth(parsed.lnurl);
                 return {
                     content: [
@@ -1604,7 +1604,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'claim_lnurl_withdraw': {
-                const parsed = ClaimLnurlWithdrawSchema.parse(args);
+                const parsed = ClaimLnurlWithdrawSchema.parse(args ?? {});
                 const result = await session.requireClient().claimLnurlWithdraw(parsed.lnurl);
                 return {
                     content: [
@@ -1622,7 +1622,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'keysend': {
-                const parsed = KeysendSchema.parse(args);
+                const parsed = KeysendSchema.parse(args ?? {});
                 const result = await session.requireClient().keysend(parsed.destination, parsed.amount_sats, parsed.message);
                 return {
                     content: [
@@ -1646,7 +1646,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
             // MESSAGE BOARD TOOL HANDLERS
             // ==========================================
             case 'board_read': {
-                const parsed = BoardReadSchema.parse(args);
+                const parsed = BoardReadSchema.parse(args ?? {});
                 const result = await session.requireClient().boardRead(parsed.sort, parsed.topic, parsed.limit, parsed.offset);
                 return {
                     content: [
@@ -1658,7 +1658,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'board_post': {
-                const parsed = BoardPostSchema.parse(args);
+                const parsed = BoardPostSchema.parse(args ?? {});
                 const result = await session.requireClient().boardPost(parsed.content, parsed.topic);
                 return {
                     content: [
@@ -1670,7 +1670,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'board_reply': {
-                const parsed = BoardReplySchema.parse(args);
+                const parsed = BoardReplySchema.parse(args ?? {});
                 const result = await session.requireClient().boardReply(parsed.post_id, parsed.content);
                 return {
                     content: [
@@ -1682,7 +1682,7 @@ server.setRequestHandler(types_js_1.CallToolRequestSchema, async (request) => {
                 };
             }
             case 'board_vote': {
-                const parsed = BoardVoteSchema.parse(args);
+                const parsed = BoardVoteSchema.parse(args ?? {});
                 const result = await session.requireClient().boardVote(parsed.post_id, parsed.direction);
                 return {
                     content: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ const PayL402ApiSchema = z.object({
 });
 
 const PayInvoiceSchema = z.object({
-  bolt11: z.string().regex(/^ln(bc|tb|bcrt)1[a-z0-9]+$/i, 'Invalid BOLT11 invoice format')
+  bolt11: z.string().regex(/^ln(bc|tb|bcrt)([0-9]+[munp]?)?1[a-z0-9]+$/i, 'Invalid BOLT11 invoice format')
     .describe('BOLT11 invoice string to pay (starts with lnbc...)'),
   max_fee_sats: z.number().min(0).optional()
     .describe('Maximum routing fee in satoshis (default: 10% of invoice amount)'),
@@ -117,7 +117,7 @@ const GetInvoiceStatusSchema = z.object({
 });
 
 const GetTransactionsSchema = z.object({
-  limit: z.number().min(1).max(200).default(50).describe('Max transactions to return'),
+  limit: z.number().min(1).max(100).default(50).describe('Max transactions to return'),
   offset: z.number().min(0).default(0).describe('Number to skip for pagination'),
 });
 
@@ -215,7 +215,7 @@ const RotateApiKeySchema = z.object({
 const GetInfoSchema = z.object({});
 
 const DecodeInvoiceSchema = z.object({
-  bolt11: z.string().regex(/^ln(bc|tb|bcrt)1[a-z0-9]+$/i, 'Invalid BOLT11 invoice format')
+  bolt11: z.string().regex(/^ln(bc|tb|bcrt)([0-9]+[munp]?)?1[a-z0-9]+$/i, 'Invalid BOLT11 invoice format')
     .describe('BOLT11 invoice string to decode'),
 });
 
@@ -223,7 +223,7 @@ const GetRateLimitsSchema = z.object({});
 
 // Tier 3 schemas
 const WithdrawSchema = z.object({
-  invoice: z.string().regex(/^ln(bc|tb|bcrt)1[a-z0-9]+$/i, 'Invalid BOLT11 invoice format')
+  invoice: z.string().regex(/^ln(bc|tb|bcrt)([0-9]+[munp]?)?1[a-z0-9]+$/i, 'Invalid BOLT11 invoice format')
     .describe('BOLT11 invoice to pay out to'),
 });
 
@@ -883,7 +883,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     switch (name) {
       case 'check_balance': {
-        CheckBalanceSchema.parse(args);
+        CheckBalanceSchema.parse(args ?? {});
         const result = await session.requireClient().checkBalance();
         return {
           content: [
@@ -900,7 +900,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'pay_l402_api': {
-        const parsed = PayL402ApiSchema.parse(args);
+        const parsed = PayL402ApiSchema.parse(args ?? {});
         const result = await session.requireClient().l402Pay(
           parsed.url,
           parsed.method,
@@ -938,7 +938,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'pay_invoice': {
-        const parsed = PayInvoiceSchema.parse(args);
+        const parsed = PayInvoiceSchema.parse(args ?? {});
         const result = await session.requireClient().payInvoice(parsed.bolt11, parsed.max_fee_sats);
         return {
           content: [
@@ -961,7 +961,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'create_invoice': {
-        const parsed = CreateInvoiceSchema.parse(args);
+        const parsed = CreateInvoiceSchema.parse(args ?? {});
         const result = await session.requireClient().createInvoice(parsed.amount_sats, parsed.memo);
         const invoiceResponse: Record<string, unknown> = {
           success: true,
@@ -984,7 +984,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'get_invoice_status': {
-        const parsed = GetInvoiceStatusSchema.parse(args);
+        const parsed = GetInvoiceStatusSchema.parse(args ?? {});
         const result = await session.requireClient().getInvoiceStatus(parsed.payment_hash);
         return {
           content: [
@@ -1005,7 +1005,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'get_transactions': {
-        const parsed = GetTransactionsSchema.parse(args);
+        const parsed = GetTransactionsSchema.parse(args ?? {});
         const result = await session.requireClient().getTransactions(parsed.limit, parsed.offset);
         return {
           content: [
@@ -1024,7 +1024,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       // Operator management tool handlers
       case 'register_operator': {
-        const parsed = RegisterOperatorSchema.parse(args);
+        const parsed = RegisterOperatorSchema.parse(args ?? {});
         const result = await registerOperator(parsed.name, parsed.email);
         // Auto-set credentials so subsequent requests use the new operator key
         session.setClient(new LightningFaucetClient(result.apiKey));
@@ -1047,7 +1047,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'update_operator': {
-        const parsed = UpdateOperatorSchema.parse(args);
+        const parsed = UpdateOperatorSchema.parse(args ?? {});
         if (parsed.email === undefined && parsed.name === undefined) {
           throw new Error('Provide email and/or name to update.');
         }
@@ -1068,7 +1068,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'claim_promo': {
-        const parsed = ClaimPromoSchema.parse(args);
+        const parsed = ClaimPromoSchema.parse(args ?? {});
         const result = await session.requireClient().claimPromo(parsed.promo_code);
         return {
           content: [
@@ -1081,7 +1081,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'get_deposit_invoice': {
-        const parsed = GetDepositInvoiceSchema.parse(args);
+        const parsed = GetDepositInvoiceSchema.parse(args ?? {});
         const result = await session.requireClient().getDepositInvoice(parsed.amount_sats);
         return {
           content: [
@@ -1102,7 +1102,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'create_agent': {
-        const parsed = CreateAgentSchema.parse(args);
+        const parsed = CreateAgentSchema.parse(args ?? {});
         const result = await session.requireClient().createAgent(
           parsed.name,
           parsed.description,
@@ -1125,7 +1125,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'fund_agent': {
-        const parsed = FundAgentSchema.parse(args);
+        const parsed = FundAgentSchema.parse(args ?? {});
         const result = await session.requireClient().fundAgent(parsed.agent_id, parsed.amount_sats);
         return {
           content: [
@@ -1144,7 +1144,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'list_agents': {
-        ListAgentsSchema.parse(args);
+        ListAgentsSchema.parse(args ?? {});
         const result = await session.requireClient().listAgents();
         return {
           content: [
@@ -1161,7 +1161,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'set_operator_key': {
-        const parsed = SetOperatorKeySchema.parse(args);
+        const parsed = SetOperatorKeySchema.parse(args ?? {});
         session.setClient(new LightningFaucetClient(parsed.api_key));
         return {
           content: [
@@ -1177,7 +1177,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'set_agent_credentials': {
-        const parsed = SetAgentCredentialsSchema.parse(args);
+        const parsed = SetAgentCredentialsSchema.parse(args ?? {});
         session.setClient(new LightningFaucetClient(parsed.api_key));
         return {
           content: [
@@ -1193,7 +1193,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'whoami': {
-        WhoamiSchema.parse(args);
+        WhoamiSchema.parse(args ?? {});
         const result = await session.requireClient().whoami();
         const response: Record<string, unknown> = {
           success: true,
@@ -1222,7 +1222,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // TIER 1: Webhook Management
       // ==========================================
       case 'register_webhook': {
-        const parsed = RegisterWebhookSchema.parse(args);
+        const parsed = RegisterWebhookSchema.parse(args ?? {});
         const result = await session.requireClient().registerWebhook(parsed.url, parsed.events);
         return {
           content: [
@@ -1242,7 +1242,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'list_webhooks': {
-        ListWebhooksSchema.parse(args);
+        ListWebhooksSchema.parse(args ?? {});
         const result = await session.requireClient().listWebhooks();
         return {
           content: [
@@ -1259,7 +1259,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'delete_webhook': {
-        const parsed = DeleteWebhookSchema.parse(args);
+        const parsed = DeleteWebhookSchema.parse(args ?? {});
         const result = await session.requireClient().deleteWebhook(parsed.webhook_id);
         return {
           content: [
@@ -1275,7 +1275,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'test_webhook': {
-        const parsed = TestWebhookSchema.parse(args);
+        const parsed = TestWebhookSchema.parse(args ?? {});
         const result = await session.requireClient().testWebhook(parsed.webhook_id);
         return {
           content: [
@@ -1295,7 +1295,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // TIER 1: Budget Management
       // ==========================================
       case 'get_budget_status': {
-        const parsed = GetBudgetStatusSchema.parse(args);
+        const parsed = GetBudgetStatusSchema.parse(args ?? {});
         const result = await session.requireClient().getBudgetStatus(parsed.agent_id);
         return {
           content: [
@@ -1315,7 +1315,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'set_budget': {
-        const parsed = SetBudgetSchema.parse(args);
+        const parsed = SetBudgetSchema.parse(args ?? {});
         const result = await session.requireClient().setBudget(parsed.agent_id, parsed.budget_limit_sats);
         return {
           content: [
@@ -1336,7 +1336,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // TIER 1: Agent Lifecycle
       // ==========================================
       case 'deactivate_agent': {
-        const parsed = DeactivateAgentSchema.parse(args);
+        const parsed = DeactivateAgentSchema.parse(args ?? {});
         const result = await session.requireClient().deactivateAgent(parsed.agent_id);
         return {
           content: [
@@ -1353,7 +1353,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'reactivate_agent': {
-        const parsed = ReactivateAgentSchema.parse(args);
+        const parsed = ReactivateAgentSchema.parse(args ?? {});
         const result = await session.requireClient().reactivateAgent(parsed.agent_id);
         return {
           content: [
@@ -1373,7 +1373,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // TIER 1: Recovery & Key Rotation
       // ==========================================
       case 'recover_account': {
-        const parsed = RecoverAccountSchema.parse(args);
+        const parsed = RecoverAccountSchema.parse(args ?? {});
         // Recovery doesn't need an existing API key — recoverAccount() uses its own fetch
         const tempClient = session.getClient() || new LightningFaucetClient('recovery-placeholder');
         const result = await tempClient.recoverAccount(parsed.recovery_code);
@@ -1396,7 +1396,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'rotate_api_key': {
-        const parsed = RotateApiKeySchema.parse(args);
+        const parsed = RotateApiKeySchema.parse(args ?? {});
         const result = await session.requireClient().rotateApiKey(parsed.agent_id);
         // Auto-switch to the new key
         session.setClient(new LightningFaucetClient(result.apiKey));
@@ -1419,7 +1419,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // TIER 2: Service Info & Invoice Decoding
       // ==========================================
       case 'get_info': {
-        GetInfoSchema.parse(args);
+        GetInfoSchema.parse(args ?? {});
         // Service info is public - fall back to an unauthenticated request so
         // first-run users can check the service before registering.
         let result;
@@ -1447,7 +1447,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'decode_invoice': {
-        const parsed = DecodeInvoiceSchema.parse(args);
+        const parsed = DecodeInvoiceSchema.parse(args ?? {});
         const result = await session.requireClient().decodeInvoice(parsed.bolt11);
         return {
           content: [
@@ -1469,7 +1469,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'get_rate_limits': {
-        GetRateLimitsSchema.parse(args);
+        GetRateLimitsSchema.parse(args ?? {});
         const result = await session.requireClient().getRateLimits();
         return {
           content: [
@@ -1490,7 +1490,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // TIER 3: Withdrawals & Advanced Payments
       // ==========================================
       case 'withdraw': {
-        const parsed = WithdrawSchema.parse(args);
+        const parsed = WithdrawSchema.parse(args ?? {});
         const result = await session.requireClient().withdraw(parsed.invoice);
         return {
           content: [
@@ -1512,9 +1512,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'create_withdraw_link': {
-        const amountSats = args && typeof args === 'object' && 'amount_sats' in args
-          ? (args as Record<string, unknown>).amount_sats as number | undefined
-          : undefined;
+        const { amount_sats: amountSats } = z.object({
+          amount_sats: z.coerce.number().int().min(100).optional(),
+        }).parse(args ?? {});
         const result = await session.requireClient().createWithdrawLink(amountSats);
         return {
           content: [
@@ -1538,7 +1538,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'sweep_agent': {
-        const parsed = SweepAgentSchema.parse(args);
+        const parsed = SweepAgentSchema.parse(args ?? {});
         const amount = typeof parsed.amount_sats === 'string' ? 999999999 : parsed.amount_sats;
         const result = await session.requireClient().sweepAgent(parsed.agent_id, amount);
         return {
@@ -1558,7 +1558,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'pay_lightning_address': {
-        const parsed = PayLightningAddressSchema.parse(args);
+        const parsed = PayLightningAddressSchema.parse(args ?? {});
         const result = await session.requireClient().payLightningAddress(
           parsed.address,
           parsed.amount_sats,
@@ -1585,7 +1585,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // NOSTR IDENTITY & ZAPS
       // ==========================================
       case 'set_nostr_identity': {
-        const parsed = SetNostrIdentitySchema.parse(args);
+        const parsed = SetNostrIdentitySchema.parse(args ?? {});
         const result = await session.requireClient().setNostrIdentity(parsed.private_key);
         return {
           content: [
@@ -1620,7 +1620,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'nostr_zap': {
-        const parsed = NostrZapSchema.parse(args);
+        const parsed = NostrZapSchema.parse(args ?? {});
         const result = await session.requireClient().nostrZap(
           parsed.address,
           parsed.amount_sats,
@@ -1652,7 +1652,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // TIER 4: Advanced Agent Management
       // ==========================================
       case 'transfer_to_agent': {
-        const parsed = TransferToAgentSchema.parse(args);
+        const parsed = TransferToAgentSchema.parse(args ?? {});
         const result = await session.requireClient().transferToAgent(
           parsed.to_agent_id,
           parsed.amount_sats,
@@ -1675,7 +1675,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'delete_agent': {
-        const parsed = DeleteAgentSchema.parse(args);
+        const parsed = DeleteAgentSchema.parse(args ?? {});
         if (!parsed.confirm) {
           return {
             content: [
@@ -1709,7 +1709,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // TIER 5: Protocol Extensions
       // ==========================================
       case 'lnurl_auth': {
-        const parsed = LnurlAuthSchema.parse(args);
+        const parsed = LnurlAuthSchema.parse(args ?? {});
         const result = await session.requireClient().lnurlAuth(parsed.lnurl);
         return {
           content: [
@@ -1726,7 +1726,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'claim_lnurl_withdraw': {
-        const parsed = ClaimLnurlWithdrawSchema.parse(args);
+        const parsed = ClaimLnurlWithdrawSchema.parse(args ?? {});
         const result = await session.requireClient().claimLnurlWithdraw(parsed.lnurl);
         return {
           content: [
@@ -1745,7 +1745,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'keysend': {
-        const parsed = KeysendSchema.parse(args);
+        const parsed = KeysendSchema.parse(args ?? {});
         const result = await session.requireClient().keysend(
           parsed.destination,
           parsed.amount_sats,
@@ -1774,7 +1774,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // MESSAGE BOARD TOOL HANDLERS
       // ==========================================
       case 'board_read': {
-        const parsed = BoardReadSchema.parse(args);
+        const parsed = BoardReadSchema.parse(args ?? {});
         const result = await session.requireClient().boardRead(
           parsed.sort,
           parsed.topic,
@@ -1792,7 +1792,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'board_post': {
-        const parsed = BoardPostSchema.parse(args);
+        const parsed = BoardPostSchema.parse(args ?? {});
         const result = await session.requireClient().boardPost(parsed.content, parsed.topic);
         return {
           content: [
@@ -1805,7 +1805,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'board_reply': {
-        const parsed = BoardReplySchema.parse(args);
+        const parsed = BoardReplySchema.parse(args ?? {});
         const result = await session.requireClient().boardReply(parsed.post_id, parsed.content);
         return {
           content: [
@@ -1818,7 +1818,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'board_vote': {
-        const parsed = BoardVoteSchema.parse(args);
+        const parsed = BoardVoteSchema.parse(args ?? {});
         const result = await session.requireClient().boardVote(parsed.post_id, parsed.direction);
         return {
           content: [


### PR DESCRIPTION
Found in a bug-hunt sweep. NOT merged and NOT published to npm — for your review (this is the published lightning-wallet-mcp client).

## SEVERE: BOLT11 regex rejected most real invoices
`/^ln(bc|tb|bcrt)1[a-z0-9]+$/i` requires the `1` separator right after the network prefix, but real invoices put the amount+multiplier there first (e.g. `lnbc2500u1...`). So `pay_invoice`, `withdraw`, and `decode_invoice` failed client-side with Invalid BOLT11 for most invoices a user pastes. Fixed to allow the optional amount segment; verified it now accepts `lnbc2500u1...`, `lnbc20m1...`, testnet/regtest, and still rejects junk.

## MED-HIGH: no-arg tools threw when arguments omitted
Every handler did `Schema.parse(args)`; the MCP `arguments` field is optional, so spec-compliant clients omitting it got `Required` instead of results. Normalized to `Schema.parse(args ?? {})`.

## MED: create_withdraw_link skipped validation
No schema; cast amount as number. Added `z.coerce.number().int().min(100).optional()`.

## LOW: get_transactions limit ceiling
Schema allowed 200 but backend caps at 100; lowered to 100.

Built with tsc; dist/index.js regenerated and included. To ship: merge, then run the lightning-wallet-mcp-release skill (npm + MCP registry).